### PR TITLE
Add isBeta flag and remove [BETA] prefix from description

### DIFF
--- a/public/vis.js
+++ b/public/vis.js
@@ -33,8 +33,9 @@ define(function (require) {
       name: 'enhanced_tilemap',
       title: 'Enhanced Coordinate Map',
       icon: 'fa-map-marker',
-      description: '[BETA] Coordinate map plugin that provides better performance,' +
+      description: 'Coordinate map plugin that provides better performance,' +
         ' complete geospatial query support, and more features than the built in Coordinate map.',
+      isBeta: true,
       category: VisType.CATEGORY.MAP,
       template: require('plugins/enhanced_tilemap/vis.html'),
       params: {


### PR DESCRIPTION

Will be used in Investigate to show this plugin is in BETA stage once https://github.com/sirensolutions/kibi-internal/pull/6847 is merged.
(See the start of the gif)

![peek 2018-09-26 11-36](https://user-images.githubusercontent.com/8244036/46075317-05ae0500-c182-11e8-96a3-e5d9836808be.gif)