### PR TITLE
Backport of 9347 to 10.2.x branch

### DIFF
--- a/public/tooltip/popupVisualize.js
+++ b/public/tooltip/popupVisualize.js
@@ -149,7 +149,12 @@ uiModules
 
         if (oldVis) $scope.renderbot = null;
         if (vis) {
-          $scope.renderbot = vis.type.createRenderbot(vis, $visEl, $scope.uiState);
+          $scope.renderbot = vis.type.createRenderbot(vis, $visEl, $scope.uiState, $scope.multiSearchData, $scope.searchSource);
+        }
+
+        // kibi: associate the vis with the searchSource
+        if ($scope.searchSource) {
+          $scope.searchSource.vis = $scope.vis;
         }
       }));
 

--- a/public/tooltip/visTooltip.js
+++ b/public/tooltip/visTooltip.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import $ from 'jquery';
 import utils from 'plugins/enhanced_tilemap/utils';
 import { SearchSourceProvider } from 'ui/courier/data_source/search_source';
+import { FilterBarQueryFilterProvider } from 'ui/filter_bar/query_filter';
 
 define(function (require) {
   return function VisTooltipFactory(
@@ -9,6 +10,7 @@ define(function (require) {
     getAppState, Private, savedVisualizations) {
 
     const geoFilter = Private(require('plugins/enhanced_tilemap/vislib/geoFilter'));
+    const queryFilter = Private(FilterBarQueryFilterProvider);
     const SearchSource = Private(SearchSourceProvider);
     const $state = getAppState();
     const UI_STATE_ID = 'popupVis';
@@ -42,6 +44,8 @@ define(function (require) {
           self.$tooltipScope.savedObj = savedVis;
           const uiState = savedVis.uiStateJSON ? JSON.parse(savedVis.uiStateJSON) : {};
           self.$tooltipScope.uiState = self.parentUiState.createChild(UI_STATE_ID, uiState, true);
+          const filters = queryFilter.getFilters();
+          self.$tooltipScope.savedObj.searchSource.filter(filters);
           self.$visEl = linkFn(self.$tooltipScope);
           $timeout(function () {
             renderbot = self.$visEl[0].getScope().renderbot;

--- a/public/vis.less
+++ b/public/vis.less
@@ -173,6 +173,10 @@ div.minicolors .minicolors-swatch {
   float: right;
 }
 
+.table {
+  background-color: white;
+  }  
+
 .tilemap-legend {
   .rzslider {
     margin: 15px 0 5px 0;

--- a/public/visController.js
+++ b/public/visController.js
@@ -129,6 +129,10 @@ define(function (require) {
       }
     });
 
+    $scope.$listen(queryFilter, 'update', function () {
+      setTooltipFormatter($scope.vis.params.tooltip);
+    });
+
     $scope.$watch('esResponse', function (resp) {
       if (_.has(resp, 'aggregations')) {
         chartData = respProcessor.process(resp);


### PR DESCRIPTION
Backport of sirensolutions/kibi-internal/issues/9357 for https://github.com/sirensolutions/kibi-internal/issues/9656

Cherry picked from 2 commits. Verified that it fixes the issue manually, i.e. the record table visualization tool-tip now appears (with working query filters) with this PR for 10.2.x branch (image below). 

![image](https://user-images.githubusercontent.com/36197976/59341701-3cbc4a80-8d00-11e9-89e2-7f5c3313b801.png)
