### PR TITLE
Separated collapsable-sidebar and etm.vis classes in vis.less

### DIFF
--- a/public/vis.less
+++ b/public/vis.less
@@ -37,11 +37,6 @@
     color: #2D2D2D;
   }
 
-  .side-by-side {
-    float: left;
-    width: 50%;
-  }
-
   .form-control-inline {
     display: inline;
     width  : auto !important;
@@ -222,6 +217,11 @@
     margin          : 0px 5px 2px 5px;
     padding         : 2px;
     position        : relative;
+  }
+
+  .side-by-side {
+    float: left;
+    width: 50%;
   }
 
   .ui-select-container {

--- a/public/vis.less
+++ b/public/vis.less
@@ -10,18 +10,6 @@
   min-width            : 0;
   overflow             : hidden;
 
-  .etm-options-section {
-    display      : block;
-    border-bottom: 2px solid #eee;
-    margin-bottom: 3px !important;
-  }
-
-  .etm-well-section {
-    display      : block;
-    border-bottom: 2px solid #ccc;
-    margin-bottom: 3px !important;
-  }
-
   .btn-input {
     padding         : 5px 15px;
     font-size       : 14px;
@@ -35,11 +23,6 @@
 
   .btn-input:hover {
     color: #2D2D2D;
-  }
-
-  .form-control-inline {
-    display: inline;
-    width  : auto !important;
   }
 
   .etm-vis .leaflet-popup-content-wrapper {
@@ -120,16 +103,6 @@
     text-align: center;
   }
 
-  .bands .minicolors-theme-bootstrap .minicolors-swatch {
-    left : inherit;
-    right: 8px;
-  }
-
-  .bands .minicolors-theme-bootstrap .minicolors-input {
-    padding-left : 4px;
-    padding-right: 44px;
-  }
-
   .bands .band-add {
     margin-top: 5px;
   }
@@ -201,6 +174,23 @@
 }
 
 .collapsible-sidebar {
+  .etm-options-section {
+    display      : block;
+    border-bottom: 2px solid #eee;
+    margin-bottom: 3px !important;
+  }
+
+  .etm-well-section {
+    display      : block;
+    border-bottom: 2px solid #ccc;
+    margin-bottom: 3px !important;
+  }
+
+  .form-control-inline {
+    display: inline;
+    width  : auto !important;
+  }
+
   div.rightCorner {
     position: absolute;
     right   : 0px;

--- a/public/vis.less
+++ b/public/vis.less
@@ -47,24 +47,6 @@
     width  : auto !important;
   }
 
-  ul.etm-options-list {
-    list-style  : none;
-    padding-left: 0;
-  }
-
-  li.etm-option-item {
-    background-color: #ecf0f1;
-    margin          : 0px 5px 2px 5px;
-    padding         : 2px;
-    position        : relative;
-  }
-
-  div.rightCorner {
-    position: absolute;
-    right   : 0px;
-    top     : 0px;
-  }
-
   .etm-vis .leaflet-popup-content-wrapper {
     box-shadow: none;
   }
@@ -177,25 +159,6 @@
     left    : -24px;
   }
 
-  .ui-select-match-item {
-    width     : 100%;
-    text-align: left;
-    height    : 22px;
-
-    .ui-select-match-close {
-      margin-top: 1px;
-    }
-
-    span[uis-transclude-append] {
-      span {
-        width        : calc(100% - 5px);
-        text-overflow: ellipsis;
-        display      : inline-block;
-        overflow     : hidden;
-      }
-    }
-  }
-
   .saved-search label {
     display: block;
   }
@@ -240,10 +203,51 @@
       display: none;
     }
   }
+}
 
-  .ui-select-bootstrap .ui-select-choices-row {
-    span {
-      padding-left: 2px;
+.collapsible-sidebar {
+  div.rightCorner {
+    position: absolute;
+    right   : 0px;
+    top     : 0px;
+  }
+
+  ul.etm-options-list {
+    list-style  : none;
+    padding-left: 0;
+  }
+
+  li.etm-option-item {
+    background-color: #ecf0f1;
+    margin          : 0px 5px 2px 5px;
+    padding         : 2px;
+    position        : relative;
+  }
+
+  .ui-select-container {
+    .ui-select-match-item {
+      width     : 100%;
+      text-align: left;
+      height    : 22px;
+
+      .ui-select-match-close {
+        margin-top: 1px;
+      }
+
+      span[uis-transclude-append] {
+        span {
+          width        : calc(100% - 5px);
+          text-overflow: ellipsis;
+          display      : inline-block;
+          overflow     : hidden;
+        }
+      }
+    }
+
+    .ui-select-bootstrap .ui-select-choices-row {
+      span {
+        padding-left: 2px;
+      }
     }
   }
 }


### PR DESCRIPTION
Areas of ETM visualization are now more clearly separated into container-sidebar (2 below) and etm-vis (1 below). 

![image](https://user-images.githubusercontent.com/36197976/59507490-12ef5900-8ea3-11e9-97a7-da2539fa22e5.png)
