### PR TITLE
Replacing rather than appending map extent bounds when "Apply Filters" is ticked

### DIFF
--- a/public/POIs.js
+++ b/public/POIs.js
@@ -59,9 +59,7 @@ define(function (require) {
           searchSource.inherits(false);
           searchSource.index(savedSearch.searchSource._state.index);
           searchSource.query(savedSearch.searchSource.get('query'));
-          const allFilters = savedSearch.searchSource.get('filter');
-          allFilters.push(createMapExtentFilter(options.mapExtentFilter));
-          searchSource.filter(allFilters);
+          searchSource.filter(createMapExtentFilter(options.mapExtentFilter));
         }
         searchSource.size(this.limit);
         searchSource.source({


### PR DESCRIPTION
This change fixed both POI issues below: 
https://github.com/sirensolutions/kibi-internal/issues/9800
https://github.com/sirensolutions/kibi-internal/issues/9803