### PR TITLE
Altering map collarscale tooltip (placement and text)

### DIFF
--- a/public/options.html
+++ b/public/options.html
@@ -3,7 +3,7 @@
   <div uib-accordion-group class="panel-default" heading="Aggregation Options">
     <div class="form-group">
       <label>
-        Map Collar Scale <kbn-info info="Use this input to increase or decrease the size of the geo aggregation filter. A value of 1 will size the filter to the map bounds. A value of 2 will size the filter to 2X the map bounds. A value too small could result in excessive fetches. A value too large could result in trimmed results and slow performance."></kbn-info>
+        Map Collar Scale <kbn-info placement="right" info="Use this input to increase or decrease the relative size of the map bounds used for the aggregation. A value of 1 will size the filter to the map bounds. A value of 2 will size the filter to 2X the map bounds. A value too large could result in excessive fetches. A value too small could result in trimmed results."></kbn-info>
       </label>
       <input type="number" class="form-control"
         name="collarScale"

--- a/public/options.html
+++ b/public/options.html
@@ -3,7 +3,7 @@
   <div uib-accordion-group class="panel-default" heading="Aggregation Options">
     <div class="form-group">
       <label>
-        Map Collar Scale <kbn-info placement="right" info="Use this input to increase or decrease the relative size of the map bounds used for the aggregation. A value of 1 will size the filter to the map bounds. A value of 2 will size the filter to 2X the map bounds. A value too large could result in excessive fetches. A value too small could result in trimmed results."></kbn-info>
+        Map Collar Scale <kbn-info placement="right" info="Use this input to increase or decrease the relative size of the map bounds used for the aggregation. A value of 1 will size the filter to the map bounds. A value of 2 will size the filter to 2X the map bounds. A value too small could result in many fetches to elasticsearch. A value too large could result in fetches that return too many results, slowing performance."></kbn-info>
       </label>
       <input type="number" class="form-control"
         name="collarScale"

--- a/public/options.html
+++ b/public/options.html
@@ -3,7 +3,7 @@
   <div uib-accordion-group class="panel-default" heading="Aggregation Options">
     <div class="form-group">
       <label>
-        Map Collar Scale <kbn-info placement="right" info="Use this input to increase or decrease the relative size of the map bounds used for the aggregation. A value of 1 will size the filter to the map bounds. A value of 2 will size the filter to 2X the map bounds. A value too small could result in many fetches to elasticsearch. A value too large could result in fetches that return too many results, slowing performance."></kbn-info>
+        Map Collar Scale <kbn-info placement="right" info="Use this input to increase or decrease the relative size of the map bounds used for the aggregation. A value of 1 will size the filter to the map bounds. A value of 2 will size the filter to 2X the map bounds. A value too small could result in many fetches to elasticsearch. A value too large could result in fetches that return trimmed results and slowing performance."></kbn-info>
       </label>
       <input type="number" class="form-control"
         name="collarScale"

--- a/public/options.html
+++ b/public/options.html
@@ -3,7 +3,7 @@
   <div uib-accordion-group class="panel-default" heading="Aggregation Options">
     <div class="form-group">
       <label>
-        Map Collar Scale <kbn-info placement="right" info="Use this input to increase or decrease the relative size of the map bounds used for the aggregation. A value of 1 will size the filter to the map bounds. A value of 2 will size the filter to 2X the map bounds. A value too small could result in many fetches to elasticsearch. A value too large could result in fetches that return trimmed results and slowing performance."></kbn-info>
+        Map Collar Scale <kbn-info placement="right" info="Use this input to increase or decrease the relative size of the map bounds used for the aggregation. A value of 1 will size the filter to the map bounds. A value of 2 will size the filter to 2X the map bounds. A value too small could result in many fetches to elasticsearch. A value too large could result in fetches that return trimmed results, slowing performance."></kbn-info>
       </label>
       <input type="number" class="form-control"
         name="collarScale"


### PR DESCRIPTION
@colmose asked you for review as you raised a very similar issue to point 1 - https://github.com/sirensolutions/kibi-internal/issues/6826

This PR addresses 2 issues that are related to the same tool tip:

1. https://github.com/sirensolutions/kibi-internal/issues/9263 - The issue is that the tooltip is hidden as the default tooltip placement is "top". I changed it to "right" and the entire tooltip is visible as below: 
![image](https://user-images.githubusercontent.com/36197976/61551076-18b0ff00-aa4c-11e9-8304-6e1db42d521f.png)


2. https://github.com/sirensolutions/kibi-internal/issues/9245 - I think this tooltip is mixed up and I investigated (below is the original tooltip text, and top orienatation): 

![image](https://user-images.githubusercontent.com/36197976/61551426-0c797180-aa4d-11e9-841a-08ec6fcc6601.png)


"A value too small could result in excessive fetches" - To me if the map collar scale is set to small number there will be less fetches

"A value too large could result in trimmed results and slow performance" - A high value results in trimmed results, meaning less documents, this is not correct. Further "and slow performance" can be removed (rather than swapping it with the point above as excessive fetches implies that performance is slowed down. 

I did some analysis on why this should be swapped. I 

- Opened an ETM visualization in edit mode
- Opened the network tab in dev tools
- Set map collar scale to 1 and applied changes. 
- When looking at the number of documents I found a total of 7126: 
![image](https://user-images.githubusercontent.com/36197976/61550914-b0621d80-aa4b-11e9-960a-cf571699171e.png)

- Then I set map collar scale to 2, applied changes and got 38,429
- Then I set map collar scale to 4, applied changes and got 57,033

These results indicate that a higher value is more likely to result in "excessive fetches" and a smaller value is more likely to result is "trimmed results". So I changed the tool tip accordingly