### PR TITLE
Layer control groups for different overlay categories

### DIFF
--- a/public/lib/leaflet.groupedlayercontrol/groupedlayerscontrol.js
+++ b/public/lib/leaflet.groupedlayercontrol/groupedlayerscontrol.js
@@ -1,0 +1,388 @@
+/* eslint-disable one-var */
+/* eslint-disable guard-for-in */
+
+// ********************************************************************************
+// This file is taken from the link below:
+// https://github.com/ismyrnow/leaflet-groupedlayercontrol/pull/57
+// It contains a 1 line fix and the npm version
+// hasn't been updated yet. If at any point the npm version is updated,
+// then the npm version of grouped-layerControl can replace this file
+// Npm ink is:
+//https://www.npmjs.com/package/leaflet-groupedlayercontrol
+// ********************************************************************************
+
+/* global L */
+
+// A layer control which provides for layer groupings.
+// Author: Ishmael Smyrnow
+L.Control.GroupedLayers = L.Control.extend({
+
+  options: {
+    collapsed: true,
+    position: 'topright',
+    autoZIndex: true,
+    exclusiveGroups: [],
+    groupCheckboxes: false
+  },
+
+  initialize: function (baseLayers, groupedOverlays, options) {
+    let i, j;
+    L.Util.setOptions(this, options);
+
+    this._layers = [];
+    this._lastZIndex = 0;
+    this._handlingClick = false;
+    this._groupList = [];
+    this._domGroups = [];
+
+    for (i in baseLayers) {
+      this._addLayer(baseLayers[i], i);
+    }
+
+    for (i in groupedOverlays) {
+      for (j in groupedOverlays[i]) {
+        this._addLayer(groupedOverlays[i][j], j, i, true);
+      }
+    }
+  },
+
+  onAdd: function (map) {
+    this._initLayout();
+    this._update();
+
+    map
+      .on('layeradd', this._onLayerChange, this)
+      .on('layerremove', this._onLayerChange, this);
+
+    return this._container;
+  },
+
+  onRemove: function (map) {
+    map
+      .off('layeradd', this._onLayerChange, this)
+      .off('layerremove', this._onLayerChange, this);
+  },
+
+  addBaseLayer: function (layer, name) {
+    this._addLayer(layer, name);
+    this._update();
+    return this;
+  },
+
+  addOverlay: function (layer, name, group) {
+    this._addLayer(layer, name, group, true);
+    this._update();
+    return this;
+  },
+
+  removeLayer: function (layer) {
+    let id = L.Util.stamp(layer);
+    let _layer = this._getLayer(id);
+    if (_layer) {
+      //delete this._layers[this._layers.indexOf(_layer)];
+      this._layers.splice(this._layers.indexOf(_layer), 1);
+    }
+    this._update();
+    return this;
+  },
+
+  _getLayer: function (id) {
+    for (let i = 0; i < this._layers.length; i++) {
+      if (this._layers[i] && L.stamp(this._layers[i].layer) === id) {
+        return this._layers[i];
+      }
+    }
+  },
+
+  _initLayout: function () {
+    let className = 'leaflet-control-layers',
+      container = this._container = L.DomUtil.create('div', className);
+
+    // Makes this work on IE10 Touch devices by stopping it from firing a mouseout event when the touch is released
+    container.setAttribute('aria-haspopup', true);
+
+    if (L.Browser.touch) {
+      L.DomEvent.on(container, 'click', L.DomEvent.stopPropagation);
+    } else {
+      L.DomEvent.disableClickPropagation(container);
+      L.DomEvent.on(container, 'wheel', L.DomEvent.stopPropagation);
+    }
+
+    let form = this._form = L.DomUtil.create('form', className + '-list');
+
+    if (this.options.collapsed) {
+      if (!L.Browser.android) {
+        L.DomEvent
+          .on(container, 'mouseover', this._expand, this)
+          .on(container, 'mouseout', this._collapse, this);
+      }
+      let link = this._layersLink = L.DomUtil.create('a', className + '-toggle', container);
+      link.href = '#';
+      link.title = 'Layers';
+
+      if (L.Browser.touch) {
+        L.DomEvent
+          .on(link, 'click', L.DomEvent.stop)
+          .on(link, 'click', this._expand, this);
+      } else {
+        L.DomEvent.on(link, 'focus', this._expand, this);
+      }
+
+      this._map.on('click', this._collapse, this);
+      // TODO keyboard accessibility
+    } else {
+      this._expand();
+    }
+
+    this._baseLayersList = L.DomUtil.create('div', className + '-base', form);
+    this._separator = L.DomUtil.create('div', className + '-separator', form);
+    this._overlaysList = L.DomUtil.create('div', className + '-overlays', form);
+
+    container.appendChild(form);
+  },
+
+  _addLayer: function (layer, name, group, overlay) {
+    let id = L.Util.stamp(layer);
+
+    let _layer = {
+      layer: layer,
+      name: name,
+      overlay: overlay
+    };
+    this._layers.push(_layer);
+
+    group = group || '';
+    let groupId = this._indexOf(this._groupList, group);
+
+    if (groupId === -1) {
+      groupId = this._groupList.push(group) - 1;
+    }
+
+    let exclusive = (this._indexOf(this.options.exclusiveGroups, group) !== -1);
+
+    _layer.group = {
+      name: group,
+      id: groupId,
+      exclusive: exclusive
+    };
+
+    if (this.options.autoZIndex && layer.setZIndex) {
+      this._lastZIndex++;
+      layer.setZIndex(this._lastZIndex);
+    }
+  },
+
+  _update: function () {
+    if (!this._container) {
+      return;
+    }
+
+    this._baseLayersList.innerHTML = '';
+    this._overlaysList.innerHTML = '';
+    this._domGroups.length = 0;
+
+    var baseLayersPresent = false,
+      overlaysPresent = false,
+      i, obj;
+
+    for (var i = 0; i < this._layers.length; i++) {
+      obj = this._layers[i];
+      this._addItem(obj);
+      overlaysPresent = overlaysPresent || obj.overlay;
+      baseLayersPresent = baseLayersPresent || !obj.overlay;
+    }
+
+    this._separator.style.display = overlaysPresent && baseLayersPresent ? '' : 'none';
+  },
+
+  _onLayerChange: function (e) {
+    let obj = this._getLayer(L.Util.stamp(e.layer)),
+      type;
+
+    if (!obj) {
+      return;
+    }
+
+    if (!this._handlingClick) {
+      this._update();
+    }
+
+    if (obj.overlay) {
+      type = e.type === 'layeradd' ? 'overlayadd' : 'overlayremove';
+    } else {
+      type = e.type === 'layeradd' ? 'baselayerchange' : null;
+    }
+
+    if (type) {
+      this._map.fire(type, obj);
+    }
+  },
+
+  // IE7 bugs out if you create a radio dynamically, so you have to do it this hacky way (see http://bit.ly/PqYLBe)
+  _createRadioElement: function (name, checked) {
+    let radioHtml = '<input type="radio" class="leaflet-control-layers-selector" name="' + name + '"';
+    if (checked) {
+      radioHtml += ' checked="checked"';
+    }
+    radioHtml += '/>';
+
+    let radioFragment = document.createElement('div');
+    radioFragment.innerHTML = radioHtml;
+
+    return radioFragment.firstChild;
+  },
+
+  _addItem: function (obj) {
+    let label = document.createElement('label'),
+      input,
+      checked = this._map.hasLayer(obj.layer),
+      container,
+      groupRadioName;
+
+    if (obj.overlay) {
+      if (obj.group.exclusive) {
+        groupRadioName = 'leaflet-exclusive-group-layer-' + obj.group.id;
+        input = this._createRadioElement(groupRadioName, checked);
+      } else {
+        input = document.createElement('input');
+        input.type = 'checkbox';
+        input.className = 'leaflet-control-layers-selector';
+        input.defaultChecked = checked;
+      }
+    } else {
+      input = this._createRadioElement('leaflet-base-layers', checked);
+    }
+
+    input.layerId = L.Util.stamp(obj.layer);
+    input.groupID = obj.group.id;
+    L.DomEvent.on(input, 'click', this._onInputClick, this);
+
+    let name = document.createElement('span');
+    name.innerHTML = ' ' + obj.name;
+
+    label.appendChild(input);
+    label.appendChild(name);
+
+    if (obj.overlay) {
+      container = this._overlaysList;
+
+      let groupContainer = this._domGroups[obj.group.id];
+
+      // Create the group container if it doesn't exist
+      if (!groupContainer) {
+        groupContainer = document.createElement('div');
+        groupContainer.className = 'leaflet-control-layers-group';
+        groupContainer.id = 'leaflet-control-layers-group-' + obj.group.id;
+
+        let groupLabel = document.createElement('label');
+        groupLabel.className = 'leaflet-control-layers-group-label';
+
+        if (obj.group.name !== '' && !obj.group.exclusive) {
+          // ------ add a group checkbox with an _onInputClickGroup function
+          if (this.options.groupCheckboxes) {
+            let groupInput = document.createElement('input');
+            groupInput.type = 'checkbox';
+            groupInput.className = 'leaflet-control-layers-group-selector';
+            groupInput.groupID = obj.group.id;
+            groupInput.legend = this;
+            L.DomEvent.on(groupInput, 'click', this._onGroupInputClick, groupInput);
+            groupLabel.appendChild(groupInput);
+          }
+        }
+
+        let groupName = document.createElement('span');
+        groupName.className = 'leaflet-control-layers-group-name';
+        groupName.innerHTML = obj.group.name;
+        groupLabel.appendChild(groupName);
+
+        groupContainer.appendChild(groupLabel);
+        container.appendChild(groupContainer);
+
+        this._domGroups[obj.group.id] = groupContainer;
+      }
+
+      container = groupContainer;
+    } else {
+      container = this._baseLayersList;
+    }
+
+    container.appendChild(label);
+
+    return label;
+  },
+
+  _onGroupInputClick: function () {
+    let i, input, obj;
+
+    let this_legend = this.legend;
+    this_legend._handlingClick = true;
+
+    let inputs = this_legend._form.getElementsByTagName('input');
+    let inputsLen = inputs.length;
+
+    for (i = 0; i < inputsLen; i++) {
+      input = inputs[i];
+      if (input.groupID === this.groupID && input.className === 'leaflet-control-layers-selector') {
+        input.checked = this.checked;
+        obj = this_legend._getLayer(input.layerId);
+        if (input.checked && !this_legend._map.hasLayer(obj.layer)) {
+          this_legend._map.addLayer(obj.layer);
+        } else if (!input.checked && this_legend._map.hasLayer(obj.layer)) {
+          this_legend._map.removeLayer(obj.layer);
+        }
+      }
+    }
+
+    this_legend._handlingClick = false;
+  },
+
+  _onInputClick: function () {
+    let i, input, obj,
+      inputs = this._form.getElementsByTagName('input'),
+      inputsLen = inputs.length;
+
+    this._handlingClick = true;
+
+    for (i = 0; i < inputsLen; i++) {
+      input = inputs[i];
+      if (input.className === 'leaflet-control-layers-selector') {
+        obj = this._getLayer(input.layerId);
+
+        if (input.checked && !this._map.hasLayer(obj.layer)) {
+          this._map.addLayer(obj.layer);
+        } else if (!input.checked && this._map.hasLayer(obj.layer)) {
+          this._map.removeLayer(obj.layer);
+        }
+      }
+    }
+
+    this._handlingClick = false;
+  },
+
+  _expand: function () {
+    L.DomUtil.addClass(this._container, 'leaflet-control-layers-expanded');
+    // permits to have a scrollbar if overlays heighter than the map.
+    let acceptableHeight = this._map._size.y - (this._container.offsetTop * 4);
+    if (acceptableHeight < this._form.clientHeight) {
+      L.DomUtil.addClass(this._form, 'leaflet-control-layers-scrollbar');
+      this._form.style.height = acceptableHeight + 'px';
+    }
+  },
+
+  _collapse: function () {
+    this._container.className = this._container.className.replace(' leaflet-control-layers-expanded', '');
+  },
+
+  _indexOf: function (arr, obj) {
+    for (let i = 0, j = arr.length; i < j; i++) {
+      if (arr[i] === obj) {
+        return i;
+      }
+    }
+    return -1;
+  }
+});
+
+L.control.groupedLayers = function (baseLayers, groupedOverlays, options) {
+  return new L.Control.GroupedLayers(baseLayers, groupedOverlays, options);
+};

--- a/public/vis.less
+++ b/public/vis.less
@@ -78,6 +78,19 @@
     p {
       margin-bottom: 1px;
     }
+
+    .leaflet-control-layers-group {
+      margin-bottom: .5em;
+    }
+
+    .leaflet-control-layers-scrollbar {
+      overflow-y   : scroll;
+      padding-right: 10px;
+    }
+
+    .leaflet-control-layers-group:not(#leaflet-control-layers-group-0) {
+      border-top: 1px solid rgb(206, 206, 206);
+    }
   }
 
   .leaflet-control-layers-overlays {

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -13,6 +13,7 @@ define(function (require) {
 
     require('leaflet-mouse-position');
     require('leaflet.nontiledlayer');
+    require('./../lib/leaflet.groupedlayercontrol/groupedlayerscontrol.js');
     require('./../lib/leaflet.setview/L.Control.SetView.css');
     require('./../lib/leaflet.setview/L.Control.SetView');
     require('./../lib/leaflet.measurescale/L.Control.MeasureScale.css');
@@ -238,10 +239,11 @@ define(function (require) {
         message: layer.$legend.tooManyDocsInfo[1]
       };
 
+      const toomanydocslayername = layerName + '  ' + tooManyDocs.icon + tooManyDocs.message;
       if (tooManyDocs.icon) {
-        this._layerControl.addOverlay(layer, layerName + '  ' + tooManyDocs.icon + tooManyDocs.message);
+        this._layerControl.addOverlay(layer, toomanydocslayername, '<b> POI Overlays</b>');
       } else {
-        this._layerControl.addOverlay(layer, layerName);
+        this._layerControl.addOverlay(layer, layerName, '<b> POI Overlays</b>');
       }
 
       this._poiLayers[layerName] = layer;
@@ -327,7 +329,9 @@ define(function (require) {
         overlay = L.tileLayer.wms(url, wmsOptions);
       }
       if (layerOptions.isVisible) this.map.addLayer(overlay);
-      this._layerControl.addOverlay(overlay, name);
+
+
+      this._layerControl.addOverlay(overlay, name, '<b> WMS Overlays</b>');
       this._wmsOverlays[name] = overlay;
       $(overlay.getContainer()).addClass('no-filter');
     };
@@ -534,7 +538,8 @@ define(function (require) {
       mapOptions.zoom = this._mapZoom;
 
       this.map = L.map(this._container, mapOptions);
-      this._layerControl = L.control.layers();
+      const options = { groupCheckboxes: true };
+      this._layerControl = L.control.groupedLayers(null, null, options);
       this._layerControl.addTo(this.map);
 
       this._addSetViewControl();


### PR DESCRIPTION
**Addressing:** 
https://github.com/sirensolutions/kibi-internal/issues/9802

How it looks when there are POI and WMS layers present: 
![DE062ACE-B862-453A-ADE2-B67EA9667FA9](https://user-images.githubusercontent.com/36197976/62429410-48c3f780-b706-11e9-94a6-76bbe4bc9409.GIF)

How it looks when one of the groups is removed (heading is also removed): 
![Snag_7a9057](https://user-images.githubusercontent.com/36197976/62429415-56797d00-b706-11e9-9aeb-f28334dbc769.png)

See comment at the top of added file for justification of adding it