### PR TITLE
Fix for WMS layer not appearing

### DIFF
--- a/public/callbacks.js
+++ b/public/callbacks.js
@@ -137,6 +137,10 @@ define(function (require) {
           field, center[0], center[1], radius);
 
         geoFilter.add(newFilter, field, indexPatternName);
+      // },
+      // reDraw: function (event) {
+      //   const agg = _.get(event, 'chart.geohashGridAgg');
+      //   console.log(agg);
       }
     };
   };

--- a/public/callbacks.js
+++ b/public/callbacks.js
@@ -68,10 +68,10 @@ define(function (require) {
         event.poiLayers.forEach(function (poiLayer) {
           poiLayer.getLayers().forEach(function (feature) {
             if (feature instanceof L.Marker) {
-              const filter = {geo_distance: {distance: event.radius + 'km'}};
+              const filter = { geo_distance: { distance: event.radius + 'km' } };
               filter.geo_distance[field] = {
-                'lat' : feature.getLatLng().lat,
-                'lon' : feature.getLatLng().lng
+                'lat': feature.getLatLng().lat,
+                'lon': feature.getLatLng().lng
               };
               filters.push(filter);
             }
@@ -91,17 +91,17 @@ define(function (require) {
           const closed = event.points;
           closed.push(firstPoint);
           field = event.params.shapeField;
-          newFilter = {geo_shape: {}};
+          newFilter = { geo_shape: {} };
           newFilter.geo_shape[field] = {
             shape: {
               type: 'Polygon',
-              coordinates: [ closed ]
+              coordinates: [closed]
             }
           };
         } else {
           field = agg.fieldName();
-          newFilter = {geo_polygon: {}};
-          newFilter.geo_polygon[field] = { points: event.points};
+          newFilter = { geo_polygon: {} };
+          newFilter.geo_polygon[field] = { points: event.points };
         }
 
         geoFilter.add(newFilter, field, indexPatternName);
@@ -137,10 +137,6 @@ define(function (require) {
           field, center[0], center[1], radius);
 
         geoFilter.add(newFilter, field, indexPatternName);
-      // },
-      // reDraw: function (event) {
-      //   const agg = _.get(event, 'chart.geohashGridAgg');
-      //   console.log(agg);
       }
     };
   };

--- a/public/visController.js
+++ b/public/visController.js
@@ -20,7 +20,7 @@ define(function (require) {
   ]);
 
   module.controller('KbnEnhancedTilemapVisController', function (
-    $scope, $rootScope, $element, $timeout, $q,
+    $scope, $rootScope, $element, $timeout,
     Private, courier, config, getAppState, indexPatterns, $http) {
     const buildChartData = Private(VislibVisTypeBuildChartDataProvider);
     const queryFilter = Private(FilterBarQueryFilterProvider);
@@ -170,9 +170,11 @@ define(function (require) {
 
     $scope.$watch(
       function () {
-        return _.filter($('div.leaflet-control-layers-overlays').find('input.leaflet-control-layers-selector'), item => {
-          return item.checked;
-        }).length;
+        const checked = $element
+          .find('div.leaflet-control-layers-overlays input.leaflet-control-layers-selector:checked');
+        if (checked) {
+          return checked.length;
+        }
       },
       function (newChecked, oldChecked) {
         if (!$scope.check) return;

--- a/public/visController.js
+++ b/public/visController.js
@@ -179,6 +179,7 @@ define(function (require) {
 
         if (newChecked !== oldChecked && $scope.check === true) {
           drawWmsOverlays();
+          $scope.vis.params.overlays.savedSearches.forEach(initPOILayer);
         }
       }
     );

--- a/public/visController.js
+++ b/public/visController.js
@@ -132,7 +132,6 @@ define(function (require) {
     }
 
     $scope.$watch('vis.params', function (visParams, oldParams) {
-
       if (visParams !== oldParams) {
         //When vis is first opened, vis.params gets updated with old context
         backwardsCompatible.updateParams($scope.vis.params);

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -322,12 +322,21 @@ define(function (require) {
     };
 
     TileMapMap.prototype.addWmsOverlay = function (url, name, wmsOptions, layerOptions) {
+      console.log("newOverlay");
+      console.log(url);
+      console.log(name);
+      console.log(wmsOptions);
+      console.log(layerOptions);
+
       let overlay = null;
       if (layerOptions.nonTiled) {
         overlay = new L.NonTiledLayer.WMS(url, wmsOptions);
       } else {
         overlay = L.tileLayer.wms(url, wmsOptions);
       }
+
+      overlay.layerOptions = layerOptions;
+
       if (layerOptions.isVisible) this.map.addLayer(overlay);
 
 
@@ -499,12 +508,32 @@ define(function (require) {
         if (self._markers && e.name === 'Aggregation') {
           self._markers.show();
         }
+        if (e.layer && e.layer.wmsParams) {
+
+          console.log(self);
+
+          //  self.__proto__.clearWMSOverlays();
+
+          console.log(this.map);
+          const layer = self._wmsOverlays[e.name];
+          self.__proto__.addWmsOverlay(layer._url, e.name, layer.options, layer.layerOptions);
+        };
+        // self._callbacks.reDraw({
+        //   chart: self._chartData,
+        //   map: self.map,
+        //   zoom: self.map.getZoom(),
+        // });
+
+
       });
 
       this.map.on('overlayremove', function (e) {
         if (self._markers && e.name === 'Aggregation') {
           self._markers.hide();
         }
+        // i f (e.layer && e.layer.wmsParams) {
+        //   self._callbacks.createMarker();
+        // }
       });
     };
 

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -322,11 +322,6 @@ define(function (require) {
     };
 
     TileMapMap.prototype.addWmsOverlay = function (url, name, wmsOptions, layerOptions) {
-      console.log("newOverlay");
-      console.log(url);
-      console.log(name);
-      console.log(wmsOptions);
-      console.log(layerOptions);
 
       let overlay = null;
       if (layerOptions.nonTiled) {
@@ -508,32 +503,12 @@ define(function (require) {
         if (self._markers && e.name === 'Aggregation') {
           self._markers.show();
         }
-        if (e.layer && e.layer.wmsParams) {
-
-          console.log(self);
-
-          //  self.__proto__.clearWMSOverlays();
-
-          console.log(this.map);
-          const layer = self._wmsOverlays[e.name];
-          self.__proto__.addWmsOverlay(layer._url, e.name, layer.options, layer.layerOptions);
-        };
-        // self._callbacks.reDraw({
-        //   chart: self._chartData,
-        //   map: self.map,
-        //   zoom: self.map.getZoom(),
-        // });
-
-
       });
 
       this.map.on('overlayremove', function (e) {
         if (self._markers && e.name === 'Aggregation') {
           self._markers.hide();
         }
-        // i f (e.layer && e.layer.wmsParams) {
-        //   self._callbacks.createMarker();
-        // }
       });
     };
 
@@ -568,7 +543,7 @@ define(function (require) {
 
       this.map = L.map(this._container, mapOptions);
       const options = { groupCheckboxes: true };
-      this._layerControl = L.control.groupedLayers(null, null, options);
+      this._layerControl = L.control.groupedLayers();
       this._layerControl.addTo(this.map);
 
       this._addSetViewControl();


### PR DESCRIPTION
https://github.com/sirensolutions/kibi-internal/issues/6833

WIP because the WMS layer control group appears at the top of the POI layers on page refresh. Then when it is re-rendered, it changes to below the POI layers. 

![069E20CD-56CC-4CA2-B1A9-0228826D8BC0](https://user-images.githubusercontent.com/36197976/62777960-f6d4f600-baa6-11e9-81c1-58a76ccc8e09.GIF)

Had to remove the checkbox option for groups for now also