### PR TITLE
More stringent check which removes a console error

### DIFF
--- a/public/directives/wmsOverlay.js
+++ b/public/directives/wmsOverlay.js
@@ -35,7 +35,7 @@ define(function (require) {
               scope.layer.wmsCapabilitiesSwitch = 0;
               //if there are selected layers present, but
               //url is not valid on this digest
-              if (scope.layer.wmsLayers.selected) {
+              if (scope.layer && scope.layer.wmsLayers && scope.layer.wmsLayers.selected) {
                 scope.layer.layers = doUiSelectFormatToLayer(scope.layer.wmsLayers.selected);
               };
             }


### PR DESCRIPTION
The change removes this error appearing in the console: 

![image](https://user-images.githubusercontent.com/36197976/62796424-226cd600-bad1-11e9-96b7-d487febd71ad.png)

