### PR TITLE
Fixing WMS compliant map server and saturation on page load

### DIFF
--- a/public/visController.js
+++ b/public/visController.js
@@ -136,6 +136,7 @@ define(function (require) {
         //When vis is first opened, vis.params gets updated with old context
         backwardsCompatible.updateParams($scope.vis.params);
 
+        map._redrawBaseLayer(visParams.wms.url, visParams.wms.options, visParams.wms.enabled);
         setTooltipFormatter(visParams.tooltip);
 
         draw();

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -526,22 +526,37 @@ define(function (require) {
       return isSame;
     };
 
+    TileMapMap.prototype._redrawBaseLayer = function (url, options, enabled) {
+      // Use WMS compliant server, if not enabled, use OSM mapTiles as default
+      if (enabled) {
+        this._tileLayer.remove();
+        this._tileLayer = L.tileLayer.wms(url, options);
+      } else {
+        this._tileLayer.remove();
+        this._tileLayer = L.tileLayer(mapTiles.url, mapTiles.options);
+      }
+      this._tileLayer.addTo(this.map);
+    };
+
     TileMapMap.prototype._createMap = function (mapOptions) {
       if (this.map) this.destroy();
 
-      // add map tiles layer, using the mapTiles object settings
+      // Use WMS compliant server, if not enabled, use OSM mapTiles as default
       if (this._attr.wms && this._attr.wms.enabled) {
         this._tileLayer = L.tileLayer.wms(this._attr.wms.url, this._attr.wms.options);
       } else {
         this._tileLayer = L.tileLayer(mapTiles.url, mapTiles.options);
       }
 
-      // append tile layers, center and zoom to the map options
-      mapOptions.layers = this._tileLayer;
       mapOptions.center = this._mapCenter;
       mapOptions.zoom = this._mapZoom;
 
       this.map = L.map(this._container, mapOptions);
+
+      // add base layer based on above logic and decide saturation based on saved settings
+      this._tileLayer.addTo(this.map);
+      this.saturateTiles(this._attr.isDesaturated);
+
       const options = { groupCheckboxes: true };
       this._layerControl = L.control.groupedLayers();
       this._layerControl.addTo(this.map);


### PR DESCRIPTION
https://github.com/sirensolutions/kibi-internal/issues/10263

I investigated this in the Enhanced TileMap plugin (there is naming confustion, it is the same vis. as enhanced coordinate map). I found two issues and this PR fixes both: 

1. Base layer (either default OSM or the one specified in vis params) only rendered on page load. 

2. Map did not desaturate/saturate based on saved vis.params on page load.

I've tested manually with the following combinations and all works as expected: 
(Page load / Vis params changes applied) **with** (deSaturated ticked / deSaturated unticked) **AND** (WMS compliant map server:  ticked / unticked)

