### PR TITLE
[WIP] - Mouse on to popup visualization and interactivity with visualization

### DIFF
--- a/public/utils.js
+++ b/public/utils.js
@@ -168,7 +168,7 @@ define(function (require) {
         widthOffset = -1 * (popupWidth - distToRightEdge);
       }
 
-      let heightOffset = 6; //leaflet default
+      let heightOffset = 16;
       const distToTopEdge = popupPoint.y;
       if (distToTopEdge < popupHeight) {
         //Move popup down as little as possible

--- a/public/vis.less
+++ b/public/vis.less
@@ -29,6 +29,10 @@
     box-shadow: none;
   }
 
+  .leaflet-popup {
+    pointer-events: auto;
+  }
+
   .interactive-popup {
     .leaflet-popup {
       pointer-events: auto;

--- a/public/vislib/marker_types/base_marker.js
+++ b/public/vislib/marker_types/base_marker.js
@@ -61,7 +61,7 @@ define(function (require) {
       let self = this;
 
       // create the legend control, keep a reference
-      self._legend = L.control({position: 'bottomright'});
+      self._legend = L.control({ position: 'bottomright' });
 
       self._legend.onAdd = function () {
         // creates all the neccessary DOM elements for the control, adds listeners
@@ -89,9 +89,9 @@ define(function (require) {
 
         _.each(self._legendColors, function (color, i) {
           let labelText = self._legendQuantizer
-          .invertExtent(color)
-          .map(self._valueFormatter)
-          .join(' – ');
+            .invertExtent(color)
+            .map(self._valueFormatter)
+            .join(' – ');
 
           let label = $('<div>').text(labelText);
 
@@ -157,7 +157,41 @@ define(function (require) {
      * return {undefined}
      */
     BaseMarker.prototype.bindPopup = function (feature, layer) {
-      let self = this;
+      const self = this;
+
+      self._popupMouseOut = function (e) {
+        // detach the event
+        L.DomEvent.off(self.map._popup, "mouseout", self._popupMouseOut, self);
+
+        // get the element that the mouse hovered onto
+        const target = e.toElement || e.relatedTarget;
+
+        // check to see if the element is a popup
+        if (this._getParent(target, "leaflet-popup")) {
+          return true;
+        }
+        // check to see if the marker was hovered back onto
+        if (target === self._icon) {
+          return true;
+        }
+
+        if (_.get(self._attr, 'tooltip.closeOnMouseout', true)) {
+          self._hidePopup();
+        }
+
+      };
+
+      self._getParent = function (element, className) {
+
+        let parent = element;
+        while (parent != null) {
+          if (parent.className && L.DomUtil.hasClass(parent, className)) {
+            return parent;
+          };
+          parent = parent.parentNode;
+        };
+        return false;
+      };
 
       let popup = layer.on({
         mouseover: function (e) {
@@ -169,6 +203,15 @@ define(function (require) {
           self._showTooltip(feature);
         },
         mouseout: function (e) {
+
+          const target = e.originalEvent.toElement || e.originalEvent.relatedTarget;
+
+          // check to see if the element is a popup
+          if (self._getParent(target, "leaflet-popup")) {
+            L.DomEvent.on(self.map._popup._container, "mouseout", self._popupMouseOut, self);
+            return true;
+          }
+
           if (_.get(self._attr, 'tooltip.closeOnMouseout', true)) {
             self._hidePopup();
           }
@@ -278,7 +321,7 @@ define(function (require) {
         this._markerGroup = L.geoJson(self.geoJson, _.defaults(defaultOptions, options));
       } else {
         //don't block UI when processing lots of features
-        this._markerGroup = L.geoJson(self.geoJson.features.slice(0,100), _.defaults(defaultOptions, options));
+        this._markerGroup = L.geoJson(self.geoJson.features.slice(0, 100), _.defaults(defaultOptions, options));
         this._stopLoadingGeohash();
 
         this._createSpinControl();
@@ -336,9 +379,9 @@ define(function (require) {
         maxWidth: 'auto',
         offset: utils.popupOffset(this.map, content, latLng)
       })
-      .setLatLng(latLng)
-      .setContent(content)
-      .openOn(this.map);
+        .setLatLng(latLng)
+        .setContent(content)
+        .openOn(this.map);
     };
 
     /**
@@ -420,7 +463,7 @@ define(function (require) {
 
         if (featureLength <= 1 || range <= 1) {
           this._legendColors = reds1;
-        } else if (featureLength <= 9  || range <= 3) {
+        } else if (featureLength <= 9 || range <= 3) {
           this._legendColors = reds3;
         } else {
           this._legendColors = reds5;

--- a/public/vislib/marker_types/base_marker.js
+++ b/public/vislib/marker_types/base_marker.js
@@ -170,10 +170,6 @@ define(function (require) {
         if (this._getParent(target, "leaflet-popup")) {
           return true;
         }
-        // check to see if the marker was hovered back onto
-        if (target === self._icon) {
-          return true;
-        }
 
         if (_.get(self._attr, 'tooltip.closeOnMouseout', true)) {
           self._hidePopup();
@@ -203,7 +199,6 @@ define(function (require) {
           self._showTooltip(feature);
         },
         mouseout: function (e) {
-
           const target = e.originalEvent.toElement || e.originalEvent.relatedTarget;
 
           // check to see if the element is a popup
@@ -369,9 +364,10 @@ define(function (require) {
 
     BaseMarker.prototype._createTooltip = function (content, latLng) {
       let className = '';
-      if (!_.get(this._attr, 'tooltip.closeOnMouseout', true)) {
+      if (_.get(this._attr, 'tooltip.type') === 'visualization') {
         className = 'interactive-popup';
       }
+
       L.popup({
         autoPan: false,
         className: className,


### PR DESCRIPTION
Currently the popup remains open from marker mouseoff to popup mouseon: 
![MouseonToVisualization](https://user-images.githubusercontent.com/36197976/63087889-207c9a00-bf4b-11e9-8a75-f30d07bba7e3.gif)

The next step is making the visualization interactive, i.e. so the scroll bar will work.

The barrier is that the CSS currently finds "leaflet-popup" pointer-event when the popup is hovered on. This means that the event is finding the leaflet-popup div as below, i.e. ... without the interactive-popup class: 

```<div class="leaflet-popup leaflet-zoom-animated" style="transform: translate3d(-28px, -191px, 0px); bottom: -16px; left: -167px;"><a class="leaflet-popup-close-button" href="#close">×</a>```

If you untick "close tooltip on mouseout", then the popup is interactive, the only difference seems to be that 'interactive-popup' is included in the class name: 

```<div class="leaflet-popup interactive-popup leaflet-zoom-animated" style="transform: translate3d(-28px, -191px, 0px); bottom: -16px; left: -167px;"><a class="leaflet-popup-close-button" href="#close">×</a>```