### PR TITLE
Issue 10336 - removal of mixed-content errors so that exporting of ETM vis will work on dashboard

### DIFF
--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -25,7 +25,7 @@ define(function (require) {
     const defaultMarkerType = 'Scaled Circle Markers';
 
     const mapTiles = {
-      url: 'http://a.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      url: 'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png',
       options: {
         attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors'
       }


### PR DESCRIPTION
Checked the export from dashboard with this PR and it was successful

To be merged with: 
https://github.com/sirensolutions/kibi-integration/pull/925
https://github.com/sirensolutions/kibi-internal/pull/10338