### PR TITLE
Handling case when no meta present in vis edit mode

### DIFF
--- a/public/callbacks.js
+++ b/public/callbacks.js
@@ -104,10 +104,7 @@ define(function (require) {
           newFilter.geo_polygon[field] = { points: event.points };
         }
 
-        let _sirenMeta = null;
-        if (agg.vis._siren && agg.vis._siren.vis) {
-          _sirenMeta = { vis: agg.vis._siren.vis };
-        };
+        const _sirenMeta = getSirenMetaFromAgg(agg);
 
         geoFilter.add(newFilter, field, indexPatternName, _sirenMeta);
       },
@@ -125,10 +122,7 @@ define(function (require) {
         const newFilter = geoFilter.rectFilter(
           field, geotype, event.bounds.top_left, event.bounds.bottom_right);
 
-        let _sirenMeta = null;
-        if (agg.vis._siren && agg.vis._siren.vis) {
-          _sirenMeta = { vis: agg.vis._siren.vis };
-        };
+        const _sirenMeta = getSirenMetaFromAgg(agg);
 
         geoFilter.add(newFilter, field, indexPatternName, _sirenMeta);
       },
@@ -146,13 +140,18 @@ define(function (require) {
         const newFilter = geoFilter.circleFilter(
           field, center[0], center[1], radius);
 
-        let _sirenMeta = null;
-        if (agg.vis._siren && agg.vis._siren.vis) {
-          _sirenMeta = { vis: agg.vis._siren.vis };
-        };
+        const _sirenMeta = getSirenMetaFromAgg(agg);
 
         geoFilter.add(newFilter, field, indexPatternName, _sirenMeta);
       }
+
+
+    };
+    function getSirenMetaFromAgg(agg) {
+      if (agg.vis._siren && agg.vis._siren.vis) {
+        return { vis: agg.vis._siren.vis };
+      };
+      return null;
     };
   };
 });

--- a/public/callbacks.js
+++ b/public/callbacks.js
@@ -104,7 +104,10 @@ define(function (require) {
           newFilter.geo_polygon[field] = { points: event.points };
         }
 
-        const _sirenMeta = { vis: agg.vis._siren.vis };
+        let _sirenMeta = null;
+        if (agg.vis._siren && agg.vis._siren.vis) {
+          _sirenMeta = { vis: agg.vis._siren.vis };
+        };
 
         geoFilter.add(newFilter, field, indexPatternName, _sirenMeta);
       },
@@ -122,7 +125,10 @@ define(function (require) {
         const newFilter = geoFilter.rectFilter(
           field, geotype, event.bounds.top_left, event.bounds.bottom_right);
 
-        const _sirenMeta = { vis: agg.vis._siren.vis };
+        let _sirenMeta = null;
+        if (agg.vis._siren && agg.vis._siren.vis) {
+          _sirenMeta = { vis: agg.vis._siren.vis };
+        };
 
         geoFilter.add(newFilter, field, indexPatternName, _sirenMeta);
       },
@@ -140,7 +146,10 @@ define(function (require) {
         const newFilter = geoFilter.circleFilter(
           field, center[0], center[1], radius);
 
-        const _sirenMeta = { vis: agg.vis._siren.vis };
+        let _sirenMeta = null;
+        if (agg.vis._siren && agg.vis._siren.vis) {
+          _sirenMeta = { vis: agg.vis._siren.vis };
+        };
 
         geoFilter.add(newFilter, field, indexPatternName, _sirenMeta);
       }

--- a/public/callbacks.js
+++ b/public/callbacks.js
@@ -5,6 +5,13 @@ define(function (require) {
     const utils = require('plugins/enhanced_tilemap/utils');
     const L = require('leaflet');
 
+    function getSirenMetaFromAgg(agg) {
+      if (agg.vis._siren && agg.vis._siren.vis) {
+        return { vis: agg.vis._siren.vis };
+      };
+      return null;
+    };
+
     return {
       createMarker: function (event) {
         const agg = _.get(event, 'chart.geohashGridAgg');
@@ -144,14 +151,6 @@ define(function (require) {
 
         geoFilter.add(newFilter, field, indexPatternName, _sirenMeta);
       }
-
-
-    };
-    function getSirenMetaFromAgg(agg) {
-      if (agg.vis._siren && agg.vis._siren.vis) {
-        return { vis: agg.vis._siren.vis };
-      };
-      return null;
     };
   };
 });


### PR DESCRIPTION
I missed a scenario when adding meta for dashboard 360 compatibility. If a user adds a geo filter in edit mode, there is a crash. 

Tested this commit in edit mode with polygon, rectangle and circle.