### PR TITLE
Making sure the first polygon vertex is the same as the last

### DIFF
--- a/public/callbacks.js
+++ b/public/callbacks.js
@@ -104,7 +104,7 @@ define(function (require) {
           newFilter.geo_shape[field] = {
             shape: {
               type: 'Polygon',
-              coordinates: [closed]
+              coordinates: [event.points]
             }
           };
         } else {

--- a/public/callbacks.js
+++ b/public/callbacks.js
@@ -95,8 +95,10 @@ define(function (require) {
         let field;
         if (event.params.filterByShape && event.params.shapeField) {
           const firstPoint = event.points[0];
-          const closed = event.points;
-          closed.push(firstPoint);
+          const lastPoint = event.points[event.points.length - 1];
+          if (firstPoint !== lastPoint) {
+            event.points.push(firstPoint);
+          }
           field = event.params.shapeField;
           newFilter = { geo_shape: {} };
           newFilter.geo_shape[field] = {

--- a/public/callbacks.js
+++ b/public/callbacks.js
@@ -96,7 +96,7 @@ define(function (require) {
         if (event.params.filterByShape && event.params.shapeField) {
           const firstPoint = event.points[0];
           const lastPoint = event.points[event.points.length - 1];
-          if (firstPoint !== lastPoint) {
+          if (!_.isEqual(firstPoint, lastPoint)) {
             event.points.push(firstPoint);
           }
           field = event.params.shapeField;

--- a/public/vislib/__tests__/callbacks.js
+++ b/public/vislib/__tests__/callbacks.js
@@ -1,0 +1,51 @@
+const _ = require('lodash');
+
+const expect = require('expect.js');
+const ngMock = require('ng_mock');
+const sinon = require('sinon');
+
+const CallbacksFactory = require('../../callbacks');
+const fakePolygonObjects = require('./fakePolygonObjects.js');
+
+describe('Kibi Enhanced Tilemap', () => {
+
+  describe('callbacks', () => {
+    let geoFilter;
+    let callbacksFactory;
+
+    beforeEach(() => {
+      ngMock.module('kibana');
+      ngMock.inject(function (Private, courier, config) {
+        callbacksFactory = new CallbacksFactory(Private, courier, config);
+        geoFilter = Private(require('plugins/enhanced_tilemap/vislib/geoFilter'));
+      });
+    });
+
+    describe('polygon', () => {
+
+      it(`the first set of coordinates should be equal to the last to produce a closed polygon`, () => {
+        const geoFilterSpy = sinon.spy(geoFilter, 'add');
+
+        let calledCount = 1;
+        _.each(fakePolygonObjects, fakePolygonObject => {
+
+          callbacksFactory.polygon(fakePolygonObject);
+          const resultingPolygon = geoFilterSpy.getCall(0).args[0].geo_shape.geo_shape_polygon.shape.coordinates[0];
+
+          const expectedPolygon = [
+            [102, 2],
+            [120, 2],
+            [120, 20],
+            [102, 20],
+            [102, 2]
+          ];
+
+          sinon.assert.callCount(geoFilterSpy, calledCount);
+          expect(resultingPolygon).to.eql(expectedPolygon);
+
+          calledCount += 1;
+        });
+      });
+    });
+  });
+});

--- a/public/vislib/__tests__/fakePolygonObjects.js
+++ b/public/vislib/__tests__/fakePolygonObjects.js
@@ -1,0 +1,45 @@
+module.exports = [
+  {
+    chart: {
+      geohashGridAgg: {
+        vis: {
+          indexPattern: {
+            id: 'index-pattern:fake'
+          }
+        }
+      }
+    },
+    params: {
+      filterByShape: true,
+      shapeField: 'geo_shape_polygon',
+    },
+    points: [
+      [102, 2],
+      [120, 2],
+      [120, 20],
+      [102, 20],
+      [102, 2]
+    ]
+  },
+  {
+    chart: {
+      geohashGridAgg: {
+        vis: {
+          indexPattern: {
+            id: 'index-pattern:fake'
+          }
+        }
+      }
+    },
+    params: {
+      filterByShape: true,
+      shapeField: 'drawn_polygon',
+    },
+    points: [
+      [102, 2],
+      [120, 2],
+      [120, 20],
+      [102, 20]
+    ]
+  }
+];


### PR DESCRIPTION
Fix for: https://github.com/sirensolutions/kibi-internal/issues/10415

Previously, clicking on the green square resulted in a malformed polygon error. Now there is no error. 

![Peek 2019-08-23 12-27](https://user-images.githubusercontent.com/36197976/63590174-02deae80-c5a3-11e9-8f01-78bc4d4113de.gif)

I've also tested the original use case where it was necessary to add the initial vertex to the end of the array:  
![polygondraw](https://user-images.githubusercontent.com/36197976/63590855-0d01ac80-c5a5-11e9-8b82-4980385f0f8c.gif)