### PR TITLE
Removal of event listeners when heatmap show tooltip is false

### DIFF
--- a/public/visController.js
+++ b/public/visController.js
@@ -138,7 +138,7 @@ define(function (require) {
 
         //remove mouse related heatmap events when moving to a different geohash type
         if (oldParams && oldParams.mapType === 'Heatmap') {
-          map._unfixMapTypeTooltips();
+          map.unfixMapTypeTooltips();
         }
 
         map._redrawBaseLayer(visParams.wms.url, visParams.wms.options, visParams.wms.enabled);

--- a/public/visController.js
+++ b/public/visController.js
@@ -136,6 +136,11 @@ define(function (require) {
         //When vis is first opened, vis.params gets updated with old context
         backwardsCompatible.updateParams($scope.vis.params);
 
+        //remove mouse related heatmap events when moving to a different geohash type
+        if (oldParams && oldParams.mapType === 'Heatmap') {
+          map._unfixMapTypeTooltips();
+        }
+
         map._redrawBaseLayer(visParams.wms.url, visParams.wms.options, visParams.wms.enabled);
         setTooltipFormatter(visParams.tooltip);
 

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -373,7 +373,7 @@ define(function (require) {
       return new MarkerType(this.map, this._geoJson, this._layerControl, options);
     };
 
-    TileMapMap.prototype._unfixMapTypeTooltips = function () {
+    TileMapMap.prototype.unfixMapTypeTooltips = function () {
       this._markers._unfixTooltips();
     };
 

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -373,6 +373,10 @@ define(function (require) {
       return new MarkerType(this.map, this._geoJson, this._layerControl, options);
     };
 
+    TileMapMap.prototype._unfixMapTypeTooltips = function () {
+      this._markers._unfixTooltips();
+    };
+
     TileMapMap.prototype._setMarkerType = function (markerType) {
       this._markerType = markerTypes[markerType] ? markerType : defaultMarkerType;
     };

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -374,7 +374,7 @@ define(function (require) {
     };
 
     TileMapMap.prototype.unfixMapTypeTooltips = function () {
-      this._markers._unfixTooltips();
+      this._markers.unfixTooltips();
     };
 
     TileMapMap.prototype._setMarkerType = function (markerType) {

--- a/public/vislib/marker_types/heatmap.js
+++ b/public/vislib/marker_types/heatmap.js
@@ -44,6 +44,13 @@ define(function (require) {
       this._addToMap();
     };
 
+    HeatmapMarker.prototype._unfixTooltips = function () {
+      this.map.off('mousemove');
+      this.map.off('mouseout');
+      this.map.off('mousedown');
+      this.map.off('mouseup');
+    };
+
     HeatmapMarker.prototype._fixTooltips = function () {
       let self = this;
       let debouncedMouseMoveLocation = _.debounce(mouseMoveLocation.bind(this), 15, {
@@ -153,8 +160,8 @@ define(function (require) {
       // range (output values) is distance in meters
       // used to compare proximity of event latlng to feature latlng
       let zoomScale = d3.scale.linear()
-      .domain([1, 4, 7, 10, 13, 16, 18])
-      .range([1000000, 300000, 100000, 15000, 2000, 150, 50]);
+        .domain([1, 4, 7, 10, 13, 16, 18])
+        .range([1000000, 300000, 100000, 15000, 2000, 150, 50]);
 
       let proximity = zoomScale(this.map.getZoom());
       let distance = latlng.distanceTo(featureLatLng);
@@ -170,8 +177,8 @@ define(function (require) {
       }
 
       let testScale = d3.scale.pow().exponent(0.2)
-      .domain([1, 18])
-      .range([1500000, 50]);
+        .domain([1, 18])
+        .range([1500000, 50]);
       return showTip;
     };
 

--- a/public/vislib/marker_types/heatmap.js
+++ b/public/vislib/marker_types/heatmap.js
@@ -44,7 +44,7 @@ define(function (require) {
       this._addToMap();
     };
 
-    HeatmapMarker.prototype._unfixTooltips = function () {
+    HeatmapMarker.prototype.unfixTooltips = function () {
       this.map.off('mousemove');
       this.map.off('mouseout');
       this.map.off('mousedown');


### PR DESCRIPTION
Fix for: https://github.com/sirensolutions/kibi-internal/issues/10395

I've tried many combinations of page refresh, changing marker type, toggling show tooltip on/off etc. Looks good: 

![HeatmapShowTooltipWorking](https://user-images.githubusercontent.com/36197976/64011315-5907a080-cb13-11e9-8763-6eef4ef6b7e8.gif)
