### PR TITLE
Create filters option on modal

### DIFF
--- a/public/vislib/geoFilter.js
+++ b/public/vislib/geoFilter.js
@@ -194,22 +194,26 @@ define(function (require) {
 
       //counting total number of filters linked to the IndexPattern of NewFilter
       const allFilters = [...queryFilter.getAppFilters(), ...queryFilter.getGlobalFilters()];
-      const newFilterVisMeta = newFilter.meta._siren.vis;
       let numFiltersInIndexPattern = 0;
 
       if (allFilters.length > 0) {
         _.each(allFilters, filter => {
-          const filterVisMeta = filter.meta._siren.vis;
-
-          if (filter.meta.index === indexPatternId &&
-            isGeoFilter(filter, field) &&
-            filterVisMeta.id === newFilterVisMeta.id &&
-            filterVisMeta.panelIndex === newFilterVisMeta.panelIndex) {
-
-            numFiltersInIndexPattern += filter.meta.numFilters;
-            existingFilter = filter;
-
-          };
+          if (newFilter.meta && newFilter.meta._siren && newFilter.meta._siren.vis) {
+            const filterVisMeta = filter.meta._siren.vis;
+            const newFilterVisMeta = newFilter.meta._siren.vis;
+            if (filter.meta.index === indexPatternId &&
+              isGeoFilter(filter, field) &&
+              filterVisMeta.id === newFilterVisMeta.id &&
+              filterVisMeta.panelIndex === newFilterVisMeta.panelIndex) {
+              numFiltersInIndexPattern += filter.meta.numFilters;
+              existingFilter = filter;
+            };
+          } else {
+            if (isGeoFilter(filter, field)) {
+              numFiltersInIndexPattern += filter.meta.numFilters;
+              existingFilter = filter;
+            };
+          }
         });
       };
 

--- a/public/vislib/geoFilter.js
+++ b/public/vislib/geoFilter.js
@@ -175,7 +175,6 @@ define(function (require) {
         updatedFilter.bool.must_not = donutsToExclude;
       };
 
-      console.log(updatedFilter);
       updatedFilter.meta.numFilters = numFilters;
       updatedFilter.meta.alias = filterAlias(field, numFilters);
       queryFilter.removeFilter(existingFilter);
@@ -192,21 +191,13 @@ define(function (require) {
 
     function addGeoFilter(newFilter, field, indexPatternName) {
       let existingFilter = null;
-      // _.flatten([queryFilter.getAppFilters(), queryFilter.getGlobalFilters()]).forEach(function (it) {
-      //   if (isGeoFilter(it, field) && ) {
-      //     existingFilter = it;
-      //   }
-      // });
-
 
       //counting total number of filters linked to the IndexPattern of NewFilter
       const allFilters = [...queryFilter.getAppFilters(), ...queryFilter.getGlobalFilters()];
       let numFiltersInIndexPattern = 0;
       if (allFilters.length > 0) {
         _.each(allFilters, filter => {
-          if ((_.isEqual(filter.meta.index, indexPatternName) &&
-            isGeoFilter(filter, field)) ||
-            numFiltersInIndexPattern < 2) {
+          if (filter.meta.index === indexPatternName && isGeoFilter(filter, field)) {
             existingFilter = filter;
             numFiltersInIndexPattern += filter.meta.numFilters;
           };

--- a/public/vislib/geoFilter.js
+++ b/public/vislib/geoFilter.js
@@ -199,12 +199,12 @@ define(function (require) {
 
       if (allFilters.length > 0) {
         _.each(allFilters, filter => {
-          const allFilters = filter.meta._siren.vis;
+          const filterVisMeta = filter.meta._siren.vis;
 
           if (filter.meta.index === indexPatternId &&
             isGeoFilter(filter, field) &&
-            allFilters.id === newFilterVisMeta.id &&
-            allFilters.panelIndex === newFilterVisMeta.panelIndex) {
+            filterVisMeta.id === newFilterVisMeta.id &&
+            filterVisMeta.panelIndex === newFilterVisMeta.panelIndex) {
 
             numFiltersInIndexPattern += filter.meta.numFilters;
             existingFilter = filter;

--- a/public/vislib/geoFilter.js
+++ b/public/vislib/geoFilter.js
@@ -1,11 +1,20 @@
 import { FilterBarQueryFilterProvider } from 'ui/filter_bar/query_filter';
+import { coatHelper } from 'ui/kibi/components/dashboards360/coat_helper';
+import React from 'react';
+import { modalWithForm } from './geoFilterModal/geoFilterModal';
+import { render, unmountComponentAtNode } from 'react-dom';
+import {
+  EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem
+} from '@elastic/eui';
 
 define(function (require) {
   const L = require('leaflet');
   const LAT_INDEX = 1;
   const LON_INDEX = 0;
 
-  return function GeoFilterFactory(Private, confirmModal) {
+  return function GeoFilterFactory(Private) {
     const _ = require('lodash');
     const queryFilter = Private(FilterBarQueryFilterProvider);
 
@@ -97,15 +106,19 @@ define(function (require) {
 
       //add all donuts
       if (polygonFiltersAndDonuts.donutsToExclude) {
+        numFilters += polygonFiltersAndDonuts.donutsToExclude.length;
         newFilter.bool.must_not = polygonFiltersAndDonuts.donutsToExclude;
       };
 
       newFilter.meta = {
+        numFilters: numFilters,
         alias: filterAlias(field, numFilters),
         negate: false,
         index: indexPatternName,
-        key: field
+        key: field,
+        _siren: _.get(newFilter, 'meta._siren', null)
       };
+
       queryFilter.addFilters(newFilter);
     };
 
@@ -113,6 +126,9 @@ define(function (require) {
       let geoFilters = [];
       let donutsToExclude = [];
       let polygonFiltersAndDonuts = {};
+
+      const updatedFilter = { meta: existingFilter.meta };
+      delete newFilter.meta;
 
       //handling new filter, also adding new donuts
       if (_.has(newFilter, 'geo_multi_polygon')) {
@@ -149,22 +165,21 @@ define(function (require) {
         geoFilters.push({ geo_distance: existingFilter.geo_distance });
       }
 
-      // Update method removed - so just remove old filter and add updated filter
-      const updatedFilter = {
-        bool: {
-          should: geoFilters
-        },
-        meta: existingFilter.meta
-      };
+      let numFilters = geoFilters.length;
 
+      // Update method removed - so just remove old filter and add updated filter
+      updatedFilter.bool = { should: geoFilters };
       // adding all donuts
-      if (donutsToExclude) {
+      if (!_.isEqual(donutsToExclude.length, 0)) {
+        numFilters += donutsToExclude.length;
         updatedFilter.bool.must_not = donutsToExclude;
       };
 
-      updatedFilter.meta.alias = filterAlias(field, geoFilters.length);
+      console.log(updatedFilter);
+      updatedFilter.meta.numFilters = numFilters;
+      updatedFilter.meta.alias = filterAlias(field, numFilters);
       queryFilter.removeFilter(existingFilter);
-      queryFilter.addFilters([updatedFilter]);
+      queryFilter.addFilters(updatedFilter);
     }
 
     function _overwriteFilters(newFilter, existingFilter, field, indexPatternName) {
@@ -177,30 +192,88 @@ define(function (require) {
 
     function addGeoFilter(newFilter, field, indexPatternName) {
       let existingFilter = null;
-      _.flatten([queryFilter.getAppFilters(), queryFilter.getGlobalFilters()]).forEach(function (it) {
-        if (isGeoFilter(it, field)) {
-          existingFilter = it;
-        }
-      });
+      // _.flatten([queryFilter.getAppFilters(), queryFilter.getGlobalFilters()]).forEach(function (it) {
+      //   if (isGeoFilter(it, field) && ) {
+      //     existingFilter = it;
+      //   }
+      // });
 
-      if (existingFilter) {
-        const confirmModalOptions = {
-          confirmButtonText: 'Combine with existing filters',
-          cancelButtonText: 'Overwrite existing filter',
-          onCancel: () => {
-            _overwriteFilters(newFilter, existingFilter, field, indexPatternName);
-          },
-          onConfirm: () => {
-            _combineFilters(newFilter, existingFilter, field);
-          }
-        };
 
-        confirmModal('How would you like this filter applied?', confirmModalOptions);
-      } else {
+      //counting total number of filters linked to the IndexPattern of NewFilter
+      const allFilters = [...queryFilter.getAppFilters(), ...queryFilter.getGlobalFilters()];
+      let numFiltersInIndexPattern = 0;
+      if (allFilters.length > 0) {
+        _.each(allFilters, filter => {
+          if ((_.isEqual(filter.meta.index, indexPatternName) &&
+            isGeoFilter(filter, field)) ||
+            numFiltersInIndexPattern < 2) {
+            existingFilter = filter;
+            numFiltersInIndexPattern += filter.meta.numFilters;
+          };
+        });
+      };
+
+      if (numFiltersInIndexPattern === 0 || numFiltersInIndexPattern >= 2) {
         _applyFilter(newFilter, field, indexPatternName);
-      }
-    }
 
+      } else if (_.isEqual(numFiltersInIndexPattern, 1)) {
+        const domNode = document.createElement('div');
+        document.body.append(domNode);
+        const title = 'Filter creation';
+        const form = 'How would you like this filter applied?';
+        const onClose = function () {
+          unmountComponentAtNode(domNode);
+          document.body.removeChild(domNode);
+        };
+        const footer = (
+          <EuiFlexGroup gutterSize="s" alignItems="center">
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                fill
+                size="s"
+                onClick={() => {
+                  _overwriteFilters(newFilter, existingFilter, field, indexPatternName);
+                  onClose();
+                }}
+              >
+                Overwrite Filter
+              </EuiButton>
+            </EuiFlexItem>
+
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                fill
+                size="s"
+                onClick={() => {
+                  _applyFilter(newFilter, field, indexPatternName);
+                  onClose();
+                }}
+              >
+                Create new filter
+              </EuiButton>
+            </EuiFlexItem>
+
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                fill
+                size="s"
+                onClick={() => {
+                  _combineFilters(newFilter, existingFilter, field);
+                  onClose();
+                }}
+              >
+                Combine with existing filters
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        );
+
+        render(
+          modalWithForm(title, form, footer, onClose),
+          domNode
+        );
+      };
+    };
     /**
      * Convert elasticsearch geospatial filter to leaflet vectors
      *

--- a/public/vislib/geoFilterModal/geoFilterModal.js
+++ b/public/vislib/geoFilterModal/geoFilterModal.js
@@ -1,0 +1,37 @@
+import {
+  EuiOverlayMask,
+  EuiModal,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiModalBody,
+  EuiModalFooter,
+} from '@elastic/eui';
+import React from 'react';
+
+function modalWithForm(title, form, footer, onClose) {
+  return (
+    <EuiOverlayMask>
+      <EuiModal
+        onClose={onClose}
+      >
+        <EuiModalHeader>
+          <EuiModalHeaderTitle >
+            {title}
+          </EuiModalHeaderTitle>
+        </EuiModalHeader>
+
+        <EuiModalBody>
+          {form}
+        </EuiModalBody>
+
+        <EuiModalFooter>
+          {footer}
+        </EuiModalFooter>
+      </EuiModal>
+    </EuiOverlayMask>
+  );
+}
+
+export {
+  modalWithForm
+};


### PR DESCRIPTION
I've tested with: 
- filters created from WFS geoJsons 
- on no linked search dashboard
- on single search dashboard
- on Dashboard360
- in vis edit mode 

**Dashboard 360 - note that the geofilters of each search are treated independently:** 
![CombineFiltersModalDB360](https://user-images.githubusercontent.com/36197976/66138261-370fab00-e5f6-11e9-9d6c-01521906a1b9.gif)

**Dashboard with no linked search - not that the filters applied of one search are applied to all:**
![CombineFiltersModal](https://user-images.githubusercontent.com/36197976/66137834-9620f000-e5f5-11e9-8642-c7302183e835.gif)

