### PR TITLE
Option whether a WMS layer is drawn on visualization load

### DIFF
--- a/public/directives/wmsOverlay.html
+++ b/public/directives/wmsOverlay.html
@@ -83,7 +83,7 @@
 
   <div class="vis-option-item form-group">
     <label>
-      <input type="checkbox" ng-model="layer.isVisible" name="layer.isVisible">
+      <input type="checkbox" ng-model="layer.isVisible" name="layer.isVisible" />
 
       Visible On Load
       

--- a/public/directives/wmsOverlay.html
+++ b/public/directives/wmsOverlay.html
@@ -80,6 +80,18 @@
       </kbn-info>
     </label>
   </div>
+
+  <div class="vis-option-item form-group">
+    <label>
+      <input type="checkbox" ng-model="layer.isVisible" name="layer.isVisible">
+
+      Visible On Load
+      
+      <kbn-info info="When true, this layer will draw when the visualization is loaded.">
+      </kbn-info>
+    </label>
+  </div>
+
   <div>
     <label class="etm-well-section">
       Elasticsearch WMS Options <kbn-info

--- a/public/visController.js
+++ b/public/visController.js
@@ -415,7 +415,7 @@ define(function (require) {
                 wmsOptions.format_options = formatOptions;
               }
               const layerOptions = {
-                isVisible: _.get(prevState, name, true),
+                isVisible: _.get(prevState, name, layerParams.isVisible),
                 nonTiled: _.get(layerParams, 'nonTiled', false)
               };
               return map.addWmsOverlay(layerParams.url, name, wmsOptions, layerOptions);


### PR DESCRIPTION
Fix for - https://github.com/sirensolutions/kibi-internal/issues/10951

All seems to be working:

Also tried ticking and unticking checkboxes in layer control

![VisibleOnLoadFinal](https://user-images.githubusercontent.com/36197976/66391993-86732400-e9c6-11e9-8017-eeee4707d3eb.gif)
