### PR TITLE
Icons working with appropriate UI changes

### DIFF
--- a/public/POIs.js
+++ b/public/POIs.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const L = require('leaflet');
-import { markerIcon } from 'plugins/enhanced_tilemap/vislib/markerIcon';
+import { searchIcon } from 'plugins/enhanced_tilemap/vislib/searchIcon';
 import { toLatLng } from 'plugins/enhanced_tilemap/vislib/geo_point';
 import { SearchSourceProvider } from 'ui/courier/data_source/search_source';
 import { FilterBarQueryFilterProvider } from 'ui/filter_bar/query_filter';
@@ -55,6 +55,11 @@ define(function (require) {
       savedSearches.get(this.savedSearchId).then(savedSearch => {
         const geoType = savedSearch.searchSource._state.index.fields.byName[self.geoField].type;
 
+        //creating icon from search for map and layerControl
+        options.iconColor = savedSearch.siren.ui.color;
+        options.searchIcon = savedSearch.siren.ui.icon;
+        const searchIcon = `<i class="${options.searchIcon}" style="color:${options.iconColor};"></i>`;
+
         function createMapExtentFilter(rect) {
           const bounds = rect.geo_bounding_box.geoBoundingBox;
           return geoFilter.rectFilter(rect.geoField.fieldname, rect.geoField.geotype, bounds.top_left, bounds.bottom_right);
@@ -105,9 +110,12 @@ define(function (require) {
             options.$legend.tooManyDocsInfo = '';
 
             if (searchResp.hits.total > this.limit) {
-              options.$legend.innerHTML = tooManyDocsInfo[0];
-              options.$legend.tooManyDocsInfo = tooManyDocsInfo;
+              options.$legend = {
+                innerHTML: tooManyDocsInfo[0],
+                tooManyDocsInfo: tooManyDocsInfo
+              };
             };
+            options.$legend.searchIcon = searchIcon;
             callback(self._createLayer(searchResp.hits.hits, geoType, options));
           });
       });
@@ -279,7 +287,7 @@ define(function (require) {
       const feature = L.marker(
         toLatLng(_.get(hit, `_source[${this.geoField}]`)),
         {
-          icon: markerIcon(options.color, options.size)
+          icon: searchIcon(options.searchIcon, options.iconColor,  options.size)
         });
 
       if (this.popupFields.length > 0) {

--- a/public/POIs.js
+++ b/public/POIs.js
@@ -108,14 +108,13 @@ define(function (require) {
 
             //Too many documents warning for each specific layer
             options.$legend.tooManyDocsInfo = '';
+            options.$legend.searchIcon = searchIcon;
 
             if (searchResp.hits.total > this.limit) {
-              options.$legend = {
-                innerHTML: tooManyDocsInfo[0],
-                tooManyDocsInfo: tooManyDocsInfo
-              };
+              options.$legend.innerHTML = tooManyDocsInfo[0];
+              options.$legend.tooManyDocsInfo = tooManyDocsInfo;
             };
-            options.$legend.searchIcon = searchIcon;
+
             callback(self._createLayer(searchResp.hits.hits, geoType, options));
           });
       });
@@ -287,7 +286,7 @@ define(function (require) {
       const feature = L.marker(
         toLatLng(_.get(hit, `_source[${this.geoField}]`)),
         {
-          icon: searchIcon(options.searchIcon, options.iconColor,  options.size)
+          icon: searchIcon(options.searchIcon, options.iconColor, options.size)
         });
 
       if (this.popupFields.length > 0) {

--- a/public/directives/savedSearch.html
+++ b/public/directives/savedSearch.html
@@ -26,20 +26,20 @@
       <label>
         Geospatial Field
       </label>
-      <select required class="form-control" ng-model="layer.geoField" ng-options="item for item in geoFields">
+      <select required class="form-control" ng-model="layer.geoField" ng-change="isGeoShape()" ng-options="item for item in geoFields">
       </select>
     </div>
     <div class="form-group">
       <label>
         Styling
       </label>
-      <input minicolors ng-model="layer.color" type="text" class="form-control" name="color" />
-      <select ng-model="layer.markerSize" class="form-control marker-size">
-        <option value="xs">xs</option>
-        <option value="s">s</option>
-        <option value="m">m</option>
-        <option value="l">l</option>
-        <option value="xl">xl</option>
+      <input minicolors ng-if="layer.geoShape === true" ng-model="layer.color" type="text" class="form-control" name="color" />
+      <select ng-if="layer.geoShape === false" ng-model="layer.markerSize" class="form-control marker-size">
+        <option value="xs">Extra small</option>
+        <option value="s">Small</option>
+        <option value="m">Medium</option>
+        <option value="l">Large</option>
+        <option value="xl">Extra Large</option>
       </select>
     </div>
 

--- a/public/directives/savedSearch.js
+++ b/public/directives/savedSearch.js
@@ -19,7 +19,19 @@ define(function (require) {
       link: function (scope, element, attrs) {
         backwardsCompatible.updateSavedSearch(scope.layer);
 
+        scope.isGeoShape = function () {
+          scope.layer.geoShape = false;
+          _.each(scope.geoFieldTypes, geoFieldType => {
+            if (scope.layer.geoField === geoFieldType.name &&
+              geoFieldType.type === 'geo_shape') {
+              scope.layer.geoShape = true;
+              return;
+            };
+          });
+        };
+
         fetchSavedSearches();
+        scope.isGeoShape();
 
         scope.updateIndex = function () {
           scope.warn = '';
@@ -29,13 +41,16 @@ define(function (require) {
           scope.layer.popupFields = [];
 
           refreshIndexFields(scope.savedSearch.indexId, function (geoFields, labelFields) {
-            scope.geoFields = geoFields;
+            scope.geoFields = geoFields.geoFieldNames;
+            scope.geoFieldTypes = geoFields.geoFieldTypes;
             scope.labelFields = labelFields;
 
             if (scope.geoFields.length === 0) {
               scope.warn = 'Unable to use selected saved search, index does not contain any geospatial fields.';
             } else if (scope.geoFields.length === 1) {
               scope.layer.geoField = scope.geoFields[0];
+
+
             }
           });
         };
@@ -78,7 +93,8 @@ define(function (require) {
                     labelFields = labelFieldsNew;
                   }
 
-                  scope.geoFields = geoFields;
+                  scope.geoFields = geoFields.geoFieldNames;
+                  scope.geoFieldTypes = geoFields.geoFieldTypes;
                   scope.labelFields = labelFields;
                 });
               }
@@ -87,13 +103,26 @@ define(function (require) {
       }
     };
 
+
+
     function refreshIndexFields(indexId, callback) {
       indexPatterns.get(indexId).then(function (index) {
-        const geoFields = index.fields.filter(function (field) {
+        const geoFieldsRaw = index.fields.filter(function (field) {
           return field.type === 'geo_point' || field.type === 'geo_shape';
-        }).map(function (field) {
-          return field.name;
         });
+
+        const geoFieldNames = [];
+        const geoFieldTypes = [];
+
+        _.each(geoFieldsRaw, individualGeoField => {
+          geoFieldNames.push(individualGeoField.name);
+          geoFieldTypes.push({
+            name: individualGeoField.name,
+            type: individualGeoField.type
+          });
+        });
+
+        const geoFields = { geoFieldNames, geoFieldTypes };
 
         const labelFields = index.fields.filter(function (field) {
           let keep = true;

--- a/public/directives/savedSearch.js
+++ b/public/directives/savedSearch.js
@@ -25,7 +25,7 @@ define(function (require) {
             if (scope.layer.geoField === geoFieldType.name &&
               geoFieldType.type === 'geo_shape') {
               scope.layer.geoShape = true;
-              return;
+              return false;
             };
           });
         };

--- a/public/vis.less
+++ b/public/vis.less
@@ -24,6 +24,32 @@
     border-radius   : 4px;
   }
 
+  .marker-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    &.xs {
+      width: 30px;
+      height: 30px;
+    }
+    &.s {
+      width: 50px;
+      height: 50px;
+    }
+    &.m {
+      width: 80px;
+      height: 80px;
+    }
+    &.l {
+      width: 200px;
+      height: 200px;
+    }
+    &.xl {
+      width: 300px;
+      height: 300px;
+    }
+  }
+
   .btn-input:hover {
     color: #2D2D2D;
   }

--- a/public/visController.js
+++ b/public/visController.js
@@ -108,7 +108,7 @@ define(function (require) {
 
     function getGeoBoundingBox() {
       //collarscale is hardcoded to exactly the size of the map canvas
-      const geoBoundingBox = utils.scaleBounds(map.mapBounds(), 1);
+      const geoBoundingBox = utils.scaleBounds(map.mapBounds(), $scope.vis.params.collarScale);
       return { geoBoundingBox };
     };
 

--- a/public/visController.js
+++ b/public/visController.js
@@ -1,3 +1,4 @@
+
 import d3 from 'd3';
 import _ from 'lodash';
 import $ from 'jquery';

--- a/public/visController.js
+++ b/public/visController.js
@@ -107,7 +107,6 @@ define(function (require) {
     });
 
     function getGeoBoundingBox() {
-      //collarscale is hardcoded to exactly the size of the map canvas
       const geoBoundingBox = utils.scaleBounds(map.mapBounds(), $scope.vis.params.collarScale);
       return { geoBoundingBox };
     };

--- a/public/visController.js
+++ b/public/visController.js
@@ -1,4 +1,3 @@
-
 import d3 from 'd3';
 import _ from 'lodash';
 import $ from 'jquery';

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -265,12 +265,13 @@ define(function (require) {
       }
 
       const tooManyDocs = {
-        icon: layer.$legend.tooManyDocsInfo[0],
+        warningIcon: layer.$legend.tooManyDocsInfo[0],
         message: layer.$legend.tooManyDocsInfo[1]
       };
 
-      const toomanydocslayername = layerName + '  ' + tooManyDocs.icon + tooManyDocs.message;
-      if (tooManyDocs.icon) {
+      layerName = `${layerName} ${layer.$legend.searchIcon}`;
+      const toomanydocslayername = layerName + ' ' + tooManyDocs.warningIcon + tooManyDocs.message;
+      if (tooManyDocs.warningIcon) {
         this._layerControl.addOverlay(layer, toomanydocslayername, '<b> POI Overlays</b>');
       } else {
         this._layerControl.addOverlay(layer, layerName, '<b> POI Overlays</b>');
@@ -290,7 +291,7 @@ define(function (require) {
       this.map.addLayer(layer);
 
       /*********************************************************/
-      // Retaining functionality of too many features to draw 
+      // Retaining functionality of too many features to draw
       // const tooManyDocs = {
       //   icon: layer.$legend.tooManyDocsInfo[0],
       //   message: layer.$legend.tooManyDocsInfo[1]

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -248,6 +248,8 @@ define(function (require) {
     TileMapMap.prototype.addPOILayer = function (layerName, layer) {
       let isVisible = true;
 
+      layerName = `${layerName} ${layer.$legend.searchIcon}`;
+
       //remove layer if it already exists
       //this is required on page load with the option to have user defined POI user
       //name in edit mode as there are two watchers, i.e. vis.params and esResponse
@@ -269,7 +271,6 @@ define(function (require) {
         message: layer.$legend.tooManyDocsInfo[1]
       };
 
-      layerName = `${layerName} ${layer.$legend.searchIcon}`;
       const toomanydocslayername = layerName + ' ' + tooManyDocs.warningIcon + tooManyDocs.message;
       if (tooManyDocs.warningIcon) {
         this._layerControl.addOverlay(layer, toomanydocslayername, '<b> POI Overlays</b>');

--- a/public/vislib/searchIcon.js
+++ b/public/vislib/searchIcon.js
@@ -1,0 +1,35 @@
+const L = require('leaflet');
+
+export const searchIcon = function (faIcon, color, size) {
+
+  let iconSize = [0,0];
+  switch (size) {
+    case 'xs':
+      faIcon = `${faIcon} fa-xs`;
+      iconSize = [30,30];
+      break;
+    case 's':
+      faIcon = `${faIcon} fa-lg`;
+      iconSize = [50,50];
+      break;
+    case 'm':
+      faIcon = `${faIcon} fa-2x`;
+      iconSize = [80,80];
+      break;
+    case 'l':
+      faIcon = `${faIcon} fa-5x`;
+      iconSize = [200,200];
+      break;
+    case 'xl':
+      faIcon = `${faIcon} fa-10x`;
+      iconSize = [300,300];
+      break;
+  }
+
+  return L.divIcon({
+    className: `search-icon`,
+    html: `<div class="marker-icon ${size}"><i class="${faIcon}" style="color:${color};"></i></div>`,
+    iconSize,
+  });
+
+};


### PR DESCRIPTION
Note - this may need to be rebased with master when the rest of the ETM PRs are merged

Works for all use cases I've tried. The UI change is whether a geo_point or geo_shape field is selected. 

If a geo_point field is selected, then the user sees an option to select an icon size. 
If a geo_shape field is selected, then the user sees an option to select the color for the polygon.  

The feature can be seen in the gif below (icon also appears in the layer control, not shown in GIF): 
![SearchIconsForPOIs](https://user-images.githubusercontent.com/36197976/66585177-49ea2880-eb7e-11e9-9576-4d6af0a77c4c.gif)
