### PR TITLE
Fix for crash when view change control is clicked

### DIFF
--- a/public/lib/leaflet.setview/L.Control.SetView.js
+++ b/public/lib/leaflet.setview/L.Control.SetView.js
@@ -97,7 +97,7 @@ L.SetViewToolbar = L.Class.extend({
       .on(input, 'dblclick', L.DomEvent.stopPropagation)
     if (options.callback) {
       L.DomEvent
-        .on(input, 'change');
+        .on(input, 'change', this.clickEvent.callback);
     }
     return input;
   },
@@ -126,7 +126,7 @@ L.SetViewToolbar = L.Class.extend({
       .off(button, 'mousedown', L.DomEvent.stopPropagation)
       .off(button, 'dblclick', L.DomEvent.stopPropagation)
       .off(button, 'click', L.DomEvent.preventDefault)
-      .off(button, 'click', this.clickEvent.callback, this.clickEvent.context);
+      .off(button, 'click', this.clickEvent.callback);
   },
   _hideActionsToolbar: function () {
     this._actionsContainer.style.display = 'none';

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -682,7 +682,7 @@ define(function (require) {
      */
     TileMapMap.prototype._getDataRectangles = function () {
       if (!this._geoJson) return [];
-      return _.pluck(this._geoJson.features, 'properties.rectangle');
+      return _.map(this._geoJson.features, 'properties.rectangle');
     };
     return TileMapMap;
   };


### PR DESCRIPTION
App now carries out desired function. 

There was a leaflet bump issue and a lodash bump issue.

https://github.com/sirensolutions/kibi-internal/issues/11152