### PR TITLE
Drag and drop - Handling case of more than one ETM on a dashboard

### DIFF
--- a/public/vis.html
+++ b/public/vis.html
@@ -1,4 +1,4 @@
-<div ng-controller="KbnEnhancedTilemapVisController" class="etm-vis">
+<div ng-controller="KbnEnhancedTilemapVisController" class="etm-vis" id="{{vis.id}}">
 
   <!-- Messages for the dashboard drag&drop -->
   <div class="siren-dashboard-drop-hover dashed-line" ng-if="showDropHover && showDropMessage">

--- a/public/visController.js
+++ b/public/visController.js
@@ -554,8 +554,9 @@ define(function (require) {
     // ============================
     // ==POI drag and drop events==
     // ============================
-    kibiState.on('drop_on_graph', dashboardId => {
-      addPOILayerFromDashboardWithModal(dashboardId);
+
+    kibiState.on('drop_on_graph', (dashboardId, droppedContainerId) => {
+      if ($scope.vis.id === droppedContainerId) addPOILayerFromDashboardWithModal(dashboardId);
     });
 
     kibiState.on('drag_on_graph', async (showDropHover, dashHasSearch, dashboardId) => {

--- a/public/visController.js
+++ b/public/visController.js
@@ -86,7 +86,7 @@ define(function (require) {
             return;
           };
 
-          let dragAndDropPoiLayer = await kibiState.getState(dashboardId);
+          const dragAndDropPoiLayer = await kibiState.getState(dashboardId);
           const index = await indexPatterns.get(dragAndDropPoiLayer.index);
 
           dragAndDropPoiLayer.savedSearchId = savedSearchId;


### PR DESCRIPTION
Has to be merged after a sister PR in kibi-internal https://github.com/sirensolutions/kibi-internal/pull/11207

Now POI overlays only render on the layer they are dragged to. 

Working: 

![POIRenderingOnMapitsDraggedTo](https://user-images.githubusercontent.com/36197976/67869223-0b181480-fb25-11e9-80d5-f3f77b8f0347.gif)