### PR TITLE
Exclude the .gradle folder when extracting investigatecore

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,8 @@ task downloadKibi(type: Copy) {
 task extractKibi(type: Copy, dependsOn: [downloadKibi]) {
     from { zipTree(new File(downloadKibi.destinationDir, "investigate-core.zip")) }
     into new File(buildDir, 'investigate-core')
+    exclude '**/.gradle/**'
+    includeEmptyDirs = false
 }
 
 /**


### PR DESCRIPTION
Based on [this answer](https://github.com/srs/gradle-node-plugin/issues/190#issuecomment-285526889), I think what is happening is that the `.gradle` folder in the downloaded and extracted investigate-core is clashing with the `.gradle` inside enhanced-tilemap. 

So the change is to exclude the `.gradle` folder from investigate-core when extracting it. 

I'm thinking we don't need the gradle setup inside investigate-core at all and should remove the whole thing but that would need some more testing.

Tested and working in https://build6.siren.io/job/snapshot/job/full-build/2752/console