### PR TITLE
Fixing layer control flickering when no aggregation layer present

### DIFF
--- a/public/visController.js
+++ b/public/visController.js
@@ -269,7 +269,7 @@ define(function (require) {
     });
 
     $scope.$watch('esResponse', function (resp) {
-      if (_.has(resp, 'aggregations')) { // && (resp.aggregations[2].doc_count > 0)) {
+      if (_.has(resp, 'aggregations')) {
         chartData = respProcessor.process(resp);
         draw();
 

--- a/public/visController.js
+++ b/public/visController.js
@@ -269,7 +269,7 @@ define(function (require) {
     });
 
     $scope.$watch('esResponse', function (resp) {
-      if (_.has(resp, 'aggregations') && (resp.aggregations[2].doc_count > 0)) {
+      if (_.has(resp, 'aggregations')) { // && (resp.aggregations[2].doc_count > 0)) {
         chartData = respProcessor.process(resp);
         draw();
 

--- a/public/vislib/marker_types/base_marker.js
+++ b/public/vislib/marker_types/base_marker.js
@@ -298,7 +298,7 @@ define(function (require) {
 
       if (this.isVisible) this.map.addLayer(this._markerGroup);
 
-      if (this.geoJson.features.length > 1) {
+      if (_.has(this, 'geoJson.features.length') && this.geoJson.features.length > 1) {
         this.addLegend();
       }
     };
@@ -352,9 +352,10 @@ define(function (require) {
             },
             200);
         }
-
-        this._addToMap();
+      } else {
+        this._markerGroup = L.geoJson();
       };
+      this._addToMap();
     };
     /**
      * Checks if event latlng is within bounds of mapData

--- a/public/vislib/marker_types/base_marker.js
+++ b/public/vislib/marker_types/base_marker.js
@@ -45,7 +45,9 @@ define(function (require) {
       this._attr = params.attr || {};
 
       // set up the default legend colors
-      this.quantizeLegendColors();
+      if (_.has(this, 'geoJson.features')) {
+        this.quantizeLegendColors();
+      }
     }
 
     /**
@@ -324,35 +326,36 @@ define(function (require) {
         }
       };
 
-      if (self.geoJson.features.length <= 250) {
-        this._markerGroup = L.geoJson(self.geoJson, _.defaults(defaultOptions, options));
-      } else {
-        //don't block UI when processing lots of features
-        this._markerGroup = L.geoJson(self.geoJson.features.slice(0, 100), _.defaults(defaultOptions, options));
-        this._stopLoadingGeohash();
+      if (_.has(self, 'geoJson.features.length')) {
+        if (self.geoJson.features.length <= 250) {
+          this._markerGroup = L.geoJson(self.geoJson, _.defaults(defaultOptions, options));
+        } else {
+          //don't block UI when processing lots of features
+          this._markerGroup = L.geoJson(self.geoJson.features.slice(0, 100), _.defaults(defaultOptions, options));
+          this._stopLoadingGeohash();
 
-        this._createSpinControl();
-        var place = 100;
-        this._intervalId = setInterval(
-          function () {
-            var stopIndex = place + 100;
-            var halt = false;
-            if (stopIndex > self.geoJson.features.length) {
-              stopIndex = self.geoJson.features.length;
-              halt = true;
-            }
-            for (var i = place; i < stopIndex; i++) {
-              place++;
-              self._markerGroup.addData(self.geoJson.features[i]);
-            }
-            if (halt) self._stopLoadingGeohash();
-          },
-          200);
-      }
+          this._createSpinControl();
+          var place = 100;
+          this._intervalId = setInterval(
+            function () {
+              var stopIndex = place + 100;
+              var halt = false;
+              if (stopIndex > self.geoJson.features.length) {
+                stopIndex = self.geoJson.features.length;
+                halt = true;
+              }
+              for (var i = place; i < stopIndex; i++) {
+                place++;
+                self._markerGroup.addData(self.geoJson.features[i]);
+              }
+              if (halt) self._stopLoadingGeohash();
+            },
+            200);
+        }
 
-      this._addToMap();
+        this._addToMap();
+      };
     };
-
     /**
      * Checks if event latlng is within bounds of mapData
      * features and shows tooltip for that feature

--- a/public/vislib/marker_types/base_marker.js
+++ b/public/vislib/marker_types/base_marker.js
@@ -298,7 +298,7 @@ define(function (require) {
 
       if (this.isVisible) this.map.addLayer(this._markerGroup);
 
-      if (_.has(this, 'geoJson.features.length') && this.geoJson.features.length > 1) {
+      if (_.has(this, 'geoJson.features.length') && this.geoJson.features.length >= 1) {
         this.addLegend();
       }
     };


### PR DESCRIPTION
Fix for - https://github.com/sirensolutions/kibi-internal/issues/11430

I handled the case of no buckets by creating a blank leaflet geoJson object for such cases. Then if there are buckets, the normal behaviour is executed. 

![FixingLayerControlFlicker](https://user-images.githubusercontent.com/36197976/69666666-85847780-1084-11ea-9f4a-4f6a4d55d425.gif)
