### PR TITLE
Handling case for join filter meta in geofilter assembly

### DIFF
--- a/public/vislib/geoFilter.js
+++ b/public/vislib/geoFilter.js
@@ -138,7 +138,7 @@ define(function (require) {
 
       if (allFilters.length > 0) {
         _.each(allFilters, filter => {
-          if (_.get(newFilter, 'meta._siren.vis')) {
+          if (_.get(newFilter, 'meta._siren.vis') && _.get(filter, 'meta._siren.vis')) {
             const filterVisMeta = filter.meta._siren.vis;
             const newFilterVisMeta = newFilter.meta._siren.vis;
             if (filter.meta.index === indexPatternId &&


### PR DESCRIPTION
Fix for: https://github.com/sirensolutions/kibi-internal/issues/11447

The screen now does not explode and filters work as intended:

![GeofilterNotExploding](https://user-images.githubusercontent.com/36197976/69732621-e0b97700-1123-11ea-96c8-bb0336598584.gif)


