### PR TITLE
Map now appears even when there are no dashboards present

### DIFF
--- a/public/visController.js
+++ b/public/visController.js
@@ -301,7 +301,7 @@ define(function (require) {
     };
 
     function draw() {
-      if (!chartData || chartData.hits === 0) {
+      if (!chartData) {
         return;
       }
       //add overlay layer to provide visibility of filtered area


### PR DESCRIPTION
Fix for: https://github.com/sirensolutions/kibi-internal/issues/11414
To be merged with: https://github.com/sirensolutions/kibi-internal/pull/11462

Checked with join filter also.

![MapStillDisplayingWhenNoDocumentsPresent](https://user-images.githubusercontent.com/36197976/69863590-2184cd80-1295-11ea-887e-a88863264ee7.gif)
