### PR TITLE
Circle filter types render on map. Partial fix for POI geo_distance filter

### DIFF
--- a/public/callbacks.js
+++ b/public/callbacks.js
@@ -75,11 +75,11 @@ define(function (require) {
                 'lat': feature.getLatLng().lat,
                 'lon': feature.getLatLng().lng
               };
-              filters.push(filter);
+              filterHelper.addSirenPropertyToFilterMeta(filter, agg.vis._siren);
+              geoFilter.add(filter, field, indexPatternName);
             }
           });
         });
-        geoFilter.add(filters, field, indexPatternName);
       },
       polygon: function (event) {
         const agg = _.get(event, 'chart.geohashGridAgg');

--- a/public/callbacks.js
+++ b/public/callbacks.js
@@ -66,7 +66,12 @@ define(function (require) {
         const field = agg.fieldName();
         const indexPatternName = agg.vis.indexPattern.id;
 
-        const filters = [];
+        const boolFilter = {
+          bool: {
+            should: []
+          }
+        };
+
         event.poiLayers.forEach(function (poiLayer) {
           poiLayer.getLayers().forEach(function (feature) {
             if (feature instanceof L.Marker) {
@@ -75,11 +80,13 @@ define(function (require) {
                 'lat': feature.getLatLng().lat,
                 'lon': feature.getLatLng().lng
               };
-              filterHelper.addSirenPropertyToFilterMeta(filter, agg.vis._siren);
-              geoFilter.add(filter, field, indexPatternName);
+
+              boolFilter.bool.should.push(filter);
             }
           });
         });
+        filterHelper.addSirenPropertyToFilterMeta(boolFilter, agg.vis._siren);
+        geoFilter.add(boolFilter, field, indexPatternName);
       },
       polygon: function (event) {
         const agg = _.get(event, 'chart.geohashGridAgg');

--- a/public/vislib/geoFilter.js
+++ b/public/vislib/geoFilter.js
@@ -43,6 +43,9 @@ define(function (require) {
         //Only analyse vector geo polygons, i.e. not drawn ones
         polygonFiltersAndDonuts = geoFilterHelper.analyseSimplePolygon(newFilter, field);
         newFilter = _createPolygonFilter(polygonFiltersAndDonuts.polygonsToFilter);
+      } else if (newFilter.bool) {
+        //currently this in only for multiple geo_distance filters
+        numShapes = newFilter.bool.should.length;
       };
 
       //add all donuts
@@ -160,7 +163,7 @@ define(function (require) {
 
       if (numFiltersFromThisInstance === 0 || numFiltersFromThisInstance >= 2) {
         _applyFilter(newFilter, field, indexPatternId);
-        
+
       } else if (numFiltersFromThisInstance === 1) {
         const domNode = document.createElement('div');
         document.body.append(domNode);

--- a/public/vislib/geoFilter.js
+++ b/public/vislib/geoFilter.js
@@ -160,7 +160,7 @@ define(function (require) {
 
       if (numFiltersFromThisInstance === 0 || numFiltersFromThisInstance >= 2) {
         _applyFilter(newFilter, field, indexPatternId);
-
+        
       } else if (numFiltersFromThisInstance === 1) {
         const domNode = document.createElement('div');
         document.body.append(domNode);
@@ -247,7 +247,10 @@ define(function (require) {
         let distance = 1000;
         if (_.includes(distanceStr, 'km')) {
           distance = parseFloat(distanceStr.replace('km', '')) * 1000;
-        }
+        } else if (typeof distanceStr === 'number') {
+          distance = distanceStr;
+        };
+
         const center = _.get(filter, ['geo_distance', field]);
         if (center) {
           features.push(L.circle([center.lat, center.lon], distance));


### PR DESCRIPTION
Fix for - https://github.com/sirensolutions/kibi-internal/issues/10803
![CircleFiltersNowDrawing](https://user-images.githubusercontent.com/36197976/69867494-dd96c600-129e-11ea-8bc8-a9c4c7d38a80.gif)

Partial fix for - https://github.com/sirensolutions/kibi-internal/issues/11463. The reason it's a partial fix is that there are likely to be many POIs and a pill for each of these still isn't acceptable. I would suggest merging this for now and adapting the issue to include the bigger case of adding bool should  filter: 
![PartialFixForPOIGeo_DistanceFilters](https://user-images.githubusercontent.com/36197976/69867587-29e20600-129f-11ea-8efb-052784ad26d3.gif)



