### PR TITLE
Fixing SetView Tool

### DIFF
--- a/public/lib/leaflet.setview/L.Control.SetView.js
+++ b/public/lib/leaflet.setview/L.Control.SetView.js
@@ -55,9 +55,18 @@ L.SetViewToolbar = L.Class.extend({
   },
   removeToolbar: function () {
     this._tools.forEach((tool) => {
-      this._dispose(tool);
+      const existingTool = this._toolEventDetails.find(toolEvent => tool.title === toolEvent.title);
+      if (existingTool) {
+        this._dispose(tool, existingTool.callback, existingTool.context);
+      };
     });
   },
+
+  _storeToolEventDetails: function (toolEventDetails) {
+    if (!this._toolEventDetails) this._toolEventDetails = [];
+    this._toolEventDetails.push(toolEventDetails);
+  },
+
   _createButton: function (options) {
     const link = L.DomUtil.create('a', options.className || '', options.container);
     link.href = '#';
@@ -67,6 +76,12 @@ L.SetViewToolbar = L.Class.extend({
     if (options.title) {
       link.title = options.title;
     }
+
+    this._storeToolEventDetails({
+      title: options.title,
+      callback: options.callback,
+      context: options.context,
+    });
 
     L.DomEvent
       .on(link, 'click', L.DomEvent.stopPropagation)
@@ -115,11 +130,13 @@ L.SetViewToolbar = L.Class.extend({
     }
     return select;
   },
-  _dispose: function (button, callback) {
+  _dispose: function (button, callback, context) {
     L.DomEvent
+      .off(button, 'click', L.DomEvent.stopPropagation)
       .off(button, 'mousedown', L.DomEvent.stopPropagation)
       .off(button, 'dblclick', L.DomEvent.stopPropagation)
-      .off(button, 'click');
+      .off(button, 'click', L.DomEvent.preventDefault)
+      .off(button, 'click', callback, context);
   },
   _hideActionsToolbar: function () {
     this._actionsContainer.style.display = 'none';

--- a/public/lib/leaflet.setview/L.Control.SetView.js
+++ b/public/lib/leaflet.setview/L.Control.SetView.js
@@ -117,10 +117,8 @@ L.SetViewToolbar = L.Class.extend({
   },
   _dispose: function (button, callback) {
     L.DomEvent
-      .off(button, 'click', L.DomEvent.stopPropagation)
       .off(button, 'mousedown', L.DomEvent.stopPropagation)
       .off(button, 'dblclick', L.DomEvent.stopPropagation)
-      .off(button, 'click', L.DomEvent.preventDefault)
       .off(button, 'click');
   },
   _hideActionsToolbar: function () {

--- a/public/lib/leaflet.setview/L.Control.SetView.js
+++ b/public/lib/leaflet.setview/L.Control.SetView.js
@@ -68,17 +68,12 @@ L.SetViewToolbar = L.Class.extend({
       link.title = options.title;
     }
 
-    this.clickEvent = {
-      callback: options.callback,
-      context: options.context
-    };
-
     L.DomEvent
       .on(link, 'click', L.DomEvent.stopPropagation)
       .on(link, 'mousedown', L.DomEvent.stopPropagation)
       .on(link, 'dblclick', L.DomEvent.stopPropagation)
       .on(link, 'click', L.DomEvent.preventDefault)
-      .on(link, 'click', this.clickEvent.callback, this.clickEvent.context);
+      .on(link, 'click', options.callback, options.context);
 
     return link;
   },
@@ -97,7 +92,7 @@ L.SetViewToolbar = L.Class.extend({
       .on(input, 'dblclick', L.DomEvent.stopPropagation);
     if (options.callback) {
       L.DomEvent
-        .on(input, 'change', this.clickEvent.callback);
+        .on(input, 'change', options.callback);
     }
     return input;
   },
@@ -126,7 +121,7 @@ L.SetViewToolbar = L.Class.extend({
       .off(button, 'mousedown', L.DomEvent.stopPropagation)
       .off(button, 'dblclick', L.DomEvent.stopPropagation)
       .off(button, 'click', L.DomEvent.preventDefault)
-      .off(button, 'click', this.clickEvent.callback);
+      .off(button, 'click');
   },
   _hideActionsToolbar: function () {
     this._actionsContainer.style.display = 'none';
@@ -161,7 +156,7 @@ L.SetViewToolbar = L.Class.extend({
       name: 'unit',
       title: 'Select coordinate units; decimal degrees (dd) or degrees minutes seconds (dms)',
       selectedValue: unitValue,
-      choices: [{ display:'dd', value: 'dd' }, { display:'dms', value: 'dms' }],
+      choices: [{ display: 'dd', value: 'dd' }, { display: 'dms', value: 'dms' }],
       callback: function (event) {
         self._decimalDegrees = !self._decimalDegrees;
         self._hideActionsToolbar();
@@ -208,7 +203,7 @@ L.SetViewToolbar = L.Class.extend({
         name: 'latDirection',
         title: 'Latitude: North or South',
         selectedValue: this._latDirection,
-        choices: [{ display:'n', value: 'n' }, { display:'s', value: 's' }],
+        choices: [{ display: 'n', value: 'n' }, { display: 's', value: 's' }],
         callback: function (event) {
           self._latDirection = self._getValue(event);
         }
@@ -231,7 +226,7 @@ L.SetViewToolbar = L.Class.extend({
         name: 'lonDirection',
         title: 'Longitude: East or West',
         selectedValue: this._lonDirection,
-        choices: [{ display:'e', value: 'e' }, { display:'w', value: 'w' }],
+        choices: [{ display: 'e', value: 'e' }, { display: 'w', value: 'w' }],
         callback: function (event) {
           self._lonDirection = self._getValue(event);
         }


### PR DESCRIPTION
Fix for  = https://github.com/sirensolutions/kibi-internal/issues/11499

I was being specific in terms of event listener cleanup. According to leaflet docs, the method of event listener removal that I have changed for this PR is sufficient to remove the listeners when the app is destroyed - https://leafletjs.com/reference-1.6.0.html#evented-off

Lat and Lon Set View tool working: 
![SetViewWorking](https://user-images.githubusercontent.com/36197976/70525066-6551bf80-1b3e-11ea-8850-138b0c8a459c.gif)
