### PR TITLE
geoFilters now created when no data present on map

### DIFF
--- a/public/vislib/__tests__/fakeCallbackObjects/fakePolygonObjects.js
+++ b/public/vislib/__tests__/fakeCallbackObjects/fakePolygonObjects.js
@@ -1,17 +1,9 @@
 module.exports = [
   {
-    chart: {
-      geohashGridAgg: {
-        vis: {
-          indexPattern: {
-            id: 'index-pattern:fake'
-          }
-        }
-      }
-    },
-    params: {
-      filterByShape: true,
-      shapeField: 'geo_shape_polygon',
+    indexPatternId: 'index-pattern:fake',
+    field: {
+      fieldname: 'geo_shape_polygon',
+      geotype: 'geo_shape'
     },
     points: [
       [102, 2],
@@ -22,18 +14,10 @@ module.exports = [
     ]
   },
   {
-    chart: {
-      geohashGridAgg: {
-        vis: {
-          indexPattern: {
-            id: 'index-pattern:fake'
-          }
-        }
-      }
-    },
-    params: {
-      filterByShape: true,
-      shapeField: 'drawn_polygon',
+    indexPatternId: 'index-pattern:fake',
+    field: {
+      fieldname: 'geo_shape_polygon',
+      geotype: 'geo_shape'
     },
     points: [
       [102, 2],

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -516,31 +516,11 @@ define(function (require) {
         }
       });
 
-      this.map.on('etm:select-feature', function (e) {
-        self._callbacks.polygon({
-          chart: self._chartData,
-          params: self._attr,
-          points: e.geojson.geometry.coordinates[0]
-        });
-      });
-
       this.map.on('etm:select-feature-vector', function (e) {
         self._callbacks.polygonVector({
           args: e.args,
           params: self._attr,
           points: e.geojson.geometry.coordinates
-        });
-      });
-
-      this.map.on('toolbench:poiFilter', function (e) {
-        const poiLayers = [];
-        Object.keys(self._poiLayers).forEach(function (key) {
-          poiLayers.push(self._poiLayers[key]);
-        });
-        self._callbacks.poiFilter({
-          chart: self._chartData,
-          poiLayers: poiLayers,
-          radius: _.get(e, 'radius', 10)
         });
       });
 
@@ -552,49 +532,6 @@ define(function (require) {
       //start popups appearing finished drawing
       this.map.on('draw:drawstop', function (e) {
         this.disablePopups = false;
-      });
-
-      this.map.on('draw:created', function (e) {
-        switch (e.layerType) {
-          case 'marker':
-            self._drawnItems.addLayer(e.layer);
-            self._callbacks.createMarker({
-              e: e,
-              chart: self._chartData,
-              latlng: e.layer._latlng
-            });
-            break;
-          case 'polygon':
-            const points = [];
-            e.layer._latlngs[0].forEach(function (latlng) {
-              const lat = L.Util.formatNum(latlng.lat, 5);
-              const lon = L.Util.formatNum(latlng.lng, 5);
-              points.push([lon, lat]);
-            });
-            self._callbacks.polygon({
-              chart: self._chartData,
-              params: self._attr,
-              points: points
-            });
-            break;
-          case 'rectangle':
-            self._callbacks.rectangle({
-              e: e,
-              chart: self._chartData,
-              params: self._attr,
-              bounds: utils.scaleBounds(e.layer.getBounds(), 1)
-            });
-            break;
-          case 'circle':
-            self._callbacks.circle({
-              e: e,
-              chart: self._chartData,
-              params: self._attr,
-            });
-            break;
-          default:
-            console.log('draw:created, unexpected layerType: ' + e.layerType);
-        }
       });
 
       this.map.on('draw:deleted', function (e) {


### PR DESCRIPTION
fix for - https://github.com/sirensolutions/kibi-internal/issues/11535

There was a return function if aggregations were not present as part of the event. This return function has been removed on the draw polygon, circle, rectangle, etc, events. This is ok to do as for the most part the only thing that was being retrieved from the event aggs object was index pattern id which is now retrieved from the visController scope instead.

I've tested with geoserver geoJsons also: 

![FiltersNowCreatedWhenNoDataPresent](https://user-images.githubusercontent.com/36197976/70908411-00490e80-2003-11ea-9e8d-8c0bb0bf957a.gif)
