### PR TITLE
Option to sync maps in vis edit mode

### DIFF
--- a/public/options.html
+++ b/public/options.html
@@ -183,6 +183,17 @@
     <div class="vis-option-item form-group">
       <label>
         <input type="checkbox"
+        name="syncMap"
+        ng-model="vis.params.syncMap">
+
+        Synchronize map
+
+        <kbn-info info="Tick this box to sync the view extent with other maps when in dashboard mode"></kbn-info>
+      </label>
+    </div>
+    <div class="vis-option-item form-group">
+      <label>
+        <input type="checkbox"
         name="wms.enabled"
         ng-model="vis.params.wms.enabled">
 

--- a/public/vis.js
+++ b/public/vis.js
@@ -79,7 +79,8 @@ define(function (require) {
         mapTypes: ['Scaled Circle Markers', 'Shaded Circle Markers', 'Shaded Geohash Grid', 'Heatmap'],
         scaleTypes: ['Dynamic - Linear', 'Dynamic - Uneven', 'Static'],
         canDesaturate: !!supports.cssFilters,
-        editor: require('plugins/enhanced_tilemap/options.html')
+        editor: require('plugins/enhanced_tilemap/options.html'),
+        syncMap: false
       },
       hierarchicalData: function (vis) {
         return false;

--- a/public/visController.js
+++ b/public/visController.js
@@ -385,13 +385,13 @@ define(function (require) {
     };
 
     function drawWmsOverlays() {
-      $scope.flags.check = false;
+
       const prevState = map.clearWMSOverlays();
       if ($scope.vis.params.overlays.wmsOverlays.length === 0) {
         return;
       }
 
-      const wmsDrawAsync = $scope.vis.params.overlays.wmsOverlays.map(function (layerParams) {
+      $scope.vis.params.overlays.wmsOverlays.map(function (layerParams) {
         const wmsIndexId = _.get(layerParams, 'indexId', $scope.vis.indexPattern.id);
         return indexPatterns.get(wmsIndexId).then(function (indexPattern) {
           const source = new courier.SearchSource();
@@ -496,9 +496,6 @@ define(function (require) {
         });
       });
 
-      Promise.all(wmsDrawAsync).then(function () {
-        $scope.flags.check = true;
-      });
     };
 
     function appendMap() {
@@ -512,7 +509,8 @@ define(function (require) {
         mapType: params.mapType,
         attr: params,
         editable: $scope.vis.getEditableVis() ? true : false,
-        uiState: $scope.vis.getUiState()
+        uiState: $scope.vis.getUiState(),
+        syncMap: params.syncMap
       });
     }
 

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -68,6 +68,7 @@ define(function (require) {
         maxBounds: L.latLngBounds([-90, -220], [90, 220]),
         scrollWheelZoom: _.get(params.attr, 'scrollWheelZoom', true),
         fadeAnimation: false,
+        syncMap: params.syncMap
       };
 
       this._createMap(mapOptions);
@@ -608,7 +609,7 @@ define(function (require) {
       this._addMousePositionControl();
       L.control.measureScale().addTo(this.map);
       this._attachEvents();
-      syncMaps.add(this.map);
+      if (mapOptions.syncMap) syncMaps.add(this.map);
     };
 
     /**


### PR DESCRIPTION
Fix for: 

https://github.com/sirensolutions/kibi-internal/issues/11575
https://sirensolutions.atlassian.net/browse/INVE-101

The Default is for the sync maps checkbox NOT to be ticked: 

![image](https://user-images.githubusercontent.com/36197976/70921462-3941ad00-201c-11ea-8e52-3fecadd54da8.png)

In the GIF below: 

Top left = companies search with sync turned ON
Top right  = companies search with sync turned OFF
Bottom left = polygontest2 search with sync turned ON
Bottom right = polygontest2 search with sync turned OFF

![SyncMapViewOptionalWorking](https://user-images.githubusercontent.com/36197976/70921233-d4865280-201b-11ea-9c33-7b98c595f179.gif)


