### PR TITLE
Fixing app crash when creating geoFilter and join filter present

### DIFF
--- a/public/vislib/geoFilter.js
+++ b/public/vislib/geoFilter.js
@@ -138,7 +138,7 @@ define(function (require) {
 
       if (allFilters.length > 0) {
         _.each(allFilters, filter => {
-          if (_.get(newFilter, 'meta._siren.vis')) {
+          if (_.get(newFilter, 'meta._siren.vis') && _.get(filter, 'meta._siren.vis')) {
             const filterVisMeta = filter.meta._siren.vis;
             const newFilterVisMeta = newFilter.meta._siren.vis;
             if (filter.meta.index === indexPatternId &&


### PR DESCRIPTION
Fix for: https://github.com/sirensolutions/kibi-internal/issues/11598

@dgilliga, this should fix that problem. It's a fix that was done for skyhook a few weeks ago. 

![PresenceOfJoinFilterNowDoesNotCrashBrowser](https://user-images.githubusercontent.com/36197976/71017992-83479300-20ef-11ea-9f5d-0a0b805e5e29.gif)
