### PR TITLE
Record table now appearing as tooltip popup when join filter is present on dashboard

### DIFF
--- a/public/tooltip/visTooltip.js
+++ b/public/tooltip/visTooltip.js
@@ -3,6 +3,7 @@ import $ from 'jquery';
 import utils from 'plugins/enhanced_tilemap/utils';
 import { SearchSourceProvider } from 'ui/courier/data_source/search_source';
 import { FilterBarQueryFilterProvider } from 'ui/filter_bar/query_filter';
+import { addSirenPropertyToVisOrSearch } from 'ui/kibi/components/dashboards360/add_property_to_vis_or_search.js';
 
 define(function (require) {
   return function VisTooltipFactory(
@@ -16,7 +17,7 @@ define(function (require) {
     const UI_STATE_ID = 'popupVis';
 
     class VisTooltip {
-      constructor(visId, fieldname, geotype, options) {
+      constructor(visId, fieldname, geotype, sirenMeta, options) {
         this.visId = visId;
         this.fieldname = fieldname;
         this.geotype = geotype;
@@ -24,6 +25,7 @@ define(function (require) {
         this.$tooltipScope = $rootScope.$new();
         this.$visEl = null;
         this.parentUiState = $state.makeStateful('uiState');
+        this.sirenMeta = sirenMeta;
       }
 
       destroy() {
@@ -69,6 +71,14 @@ define(function (require) {
 
           //Flag identifies that this is a record table vis, required for doc_table.js
           self.$tooltipScope.savedObj.searchSource.replaceHits = true;
+
+          if (self.sirenMeta) {
+            //the assumption is that the popup visualization is always
+            // based on the same saved search as the map vis
+            const panelIndexObj = { panelIndex: self.sirenMeta.vis.panelIndex };
+            self.$tooltipScope.savedObj.mapVisId = self.sirenMeta.vis.id;
+            addSirenPropertyToVisOrSearch(self.$tooltipScope.savedObj, self.sirenMeta, panelIndexObj);
+          };
 
           //adding pre-existing filter(s) and geohash specific filter to popup visualization
           self.$tooltipScope.savedObj.searchSource._state.filter = [];

--- a/public/tooltip/visTooltip.js
+++ b/public/tooltip/visTooltip.js
@@ -73,11 +73,24 @@ define(function (require) {
           self.$tooltipScope.savedObj.searchSource.replaceHits = true;
 
           if (self.sirenMeta) {
-            //the assumption is that the popup visualization is always
-            // based on the same saved search as the map vis
-            const panelIndexObj = { panelIndex: self.sirenMeta.vis.panelIndex };
-            self.$tooltipScope.savedObj.mapVisId = self.sirenMeta.vis.id;
-            addSirenPropertyToVisOrSearch(self.$tooltipScope.savedObj, self.sirenMeta, panelIndexObj);
+            //the required meta information is already in the coat. Below is the logic to retrive it and assign it to
+            const panelIndexObj = {};
+            //cloneDeep required as main dashboard count updates on popup creation otherwise
+            const sirenMetaTooltip = _.cloneDeep(self.sirenMeta);
+            self.sirenMeta.coat.items.forEach(item => {
+              if (item.type === 'node' && item.d.entity.id === self.sirenMeta.coat.node.d.entity.id) {
+                item.d.widgets.forEach(widget => {
+                  if (widget.id === self.visId) {
+                    panelIndexObj.panelIndex = widget.panelIndex;
+                    sirenMetaTooltip.vis.id = widget.id;
+                    sirenMetaTooltip.vis.title = widget.title;
+                    sirenMetaTooltip.vis.panelIndex = widget.panelIndex;
+                  };
+                });
+              }
+            });
+
+            addSirenPropertyToVisOrSearch(self.$tooltipScope.savedObj, sirenMetaTooltip, panelIndexObj);
           };
 
           //adding pre-existing filter(s) and geohash specific filter to popup visualization

--- a/public/visController.js
+++ b/public/visController.js
@@ -57,7 +57,7 @@ define(function (require) {
     createDragAndDropPoiLayers();
     appendMap();
     modifyToDsl();
-    setTooltipFormatter($scope.vis.params.tooltip);
+    setTooltipFormatter($scope.vis.params.tooltip, $scope.vis._siren);
     drawWfsOverlays();
 
     const shapeFields = $scope.vis.indexPattern.fields.filter(function (field) {
@@ -192,7 +192,7 @@ define(function (require) {
       };
 
       const differentTimeOrState = !kibiState.compareStates(newState, storedState).stateEqual ||
-      !kibiState.compareTimes(newTime, storedTime);
+        !kibiState.compareTimes(newTime, storedTime);
 
       if (calledFromVisParams || differentTimeOrState) {
         storedTime = _.cloneDeep(newTime);
@@ -308,7 +308,7 @@ define(function (require) {
         }
 
         map._redrawBaseLayer(visParams.wms.url, visParams.wms.options, visParams.wms.enabled);
-        setTooltipFormatter(visParams.tooltip);
+        setTooltipFormatter(visParams.tooltip, $scope.vis._siren);
 
         draw();
 
@@ -324,7 +324,7 @@ define(function (require) {
     });
 
     $scope.$listen(queryFilter, 'update', function () {
-      setTooltipFormatter($scope.vis.params.tooltip);
+      setTooltipFormatter($scope.vis.params.tooltip, $scope.vis._siren);
     });
 
     $scope.$watch('esResponse', function (resp) {
@@ -380,7 +380,7 @@ define(function (require) {
 
     }
 
-    function setTooltipFormatter(tooltipParams) {
+    function setTooltipFormatter(tooltipParams, sirenMeta) {
       if (tooltip) {
         tooltip.destroy();
       }
@@ -395,7 +395,9 @@ define(function (require) {
           _.get(tooltipParams, 'options.visId'),
           geoField.fieldname,
           geoField.geotype,
-          options);
+          sirenMeta,
+          options
+        );
         tooltipFormatter = tooltip.getFormatter();
       } else {
         tooltipFormatter = Private(TileMapTooltipFormatterProvider);

--- a/public/vislib/marker_types/geohash_grid.js
+++ b/public/vislib/marker_types/geohash_grid.js
@@ -14,12 +14,7 @@ define(function (require) {
      */
     _.class(GeohashGridMarker).inherits(BaseMarker);
     function GeohashGridMarker(map, geoJson, params) {
-      const self = this;
       GeohashGridMarker.Super.apply(this, arguments);
-
-      // super min and max from all chart data
-      const min = this.geoJson.properties.allmin;
-      const max = this.geoJson.properties.allmax;
 
       this._createMarkerGroup({
         pointToLayer: function (feature, latlng) {

--- a/public/vislib/marker_types/shaded_circles.js
+++ b/public/vislib/marker_types/shaded_circles.js
@@ -17,10 +17,6 @@ define(function (require) {
       const self = this;
       ShadedCircleMarker.Super.apply(this, arguments);
 
-      // super min and max from all chart data
-      const min = this.geoJson.properties.allmin;
-      const max = this.geoJson.properties.allmax;
-
       // multiplier to reduce size of all circles
       const scaleFactor = 0.8;
 
@@ -50,15 +46,15 @@ define(function (require) {
       //   clockwise, each value being an array of [lat, lng]
 
       // center lat and southeast lng
-      const east   = L.latLng([centerPoint[0], geohashRect[2][1]]);
+      const east = L.latLng([centerPoint[0], geohashRect[2][1]]);
       // southwest lat and center lng
-      const north  = L.latLng([geohashRect[3][0], centerPoint[1]]);
+      const north = L.latLng([geohashRect[3][0], centerPoint[1]]);
 
       // get latLng of geohash center point
       const center = L.latLng([centerPoint[0], centerPoint[1]]);
 
       // get smallest radius at center of geohash grid rectangle
-      const eastRadius  = Math.floor(center.distanceTo(east));
+      const eastRadius = Math.floor(center.distanceTo(east));
       const northRadius = Math.floor(center.distanceTo(north));
       return _.min([eastRadius, northRadius]);
     };


### PR DESCRIPTION
Fix for - https://github.com/sirensolutions/kibi-internal/issues/11536
To be merged with - https://github.com/sirensolutions/kibi-internal/pull/11629

Note that the records in the record table within the map correspond to the record table on the dashboard when a rectangular filter is created: 

![CorrectFiltersForVisualizationPopups](https://user-images.githubusercontent.com/36197976/71680960-619f0a80-2d83-11ea-9d30-44ca6035d24e.gif)
