### PR TITLE
Changing reference to leaflet map object from map to leafletMap

### DIFF
--- a/public/POIs.js
+++ b/public/POIs.js
@@ -425,7 +425,7 @@ define(function (require) {
         if (!e.target._map.disablePopups) {
           const popupDimensions = {
             height: this._map.getSize().y * 0.9,
-            width: 400
+            width: Math.min(this._map.getSize().x * 0.9, 400)
           };
           L.popup({
             autoPan: false,

--- a/public/POIs.js
+++ b/public/POIs.js
@@ -423,11 +423,15 @@ define(function (require) {
     POIs.prototype._getMouseOverGeoPoint = function (content) {
       const popup = function (e) {
         if (!e.target._map.disablePopups) {
+          const popupDimensions = {
+            height: this._map.getSize().y * 0.9,
+            width: 400
+          };
           L.popup({
             autoPan: false,
-            maxHeight: 'auto',
-            maxWidth: 'auto',
-            offset: utils.popupOffset(this._map, content, e.latlng)
+            maxHeight: popupDimensions.height,
+            maxWidth: popupDimensions.width,
+            offset: utils.popupOffset(this._map, content, e.latlng, popupDimensions)
           })
             .setLatLng(e.latlng)
             .setContent(content)

--- a/public/tooltip/searchTooltip.js
+++ b/public/tooltip/searchTooltip.js
@@ -61,12 +61,12 @@ define(function (require) {
           return geoFilter.rectFilter(self.fieldname, self.geotype, bounds.top_left, bounds.bottom_right);
         }
 
-        return function (feature, map) {
+        return function (feature, leafletMap) {
           if (!feature) return '';
           if (!self.$visEl) return 'initializing';
 
-          const width = Math.round(map.getSize().x * _.get(self.options, 'xRatio', 0.6));
-          const height = Math.round(map.getSize().y * _.get(self.options, 'yRatio', 0.6));
+          const width = Math.round(leafletMap.getSize().x * _.get(self.options, 'xRatio', 0.6));
+          const height = Math.round(leafletMap.getSize().y * _.get(self.options, 'yRatio', 0.6));
           const style = 'style="height: ' + height + 'px; width: ' + width + 'px;"';
           const loadHtml = '<div ' + style + '>Loading Data</div>';
 
@@ -81,7 +81,7 @@ define(function (require) {
               height: height
             });
 
-            const $popup = $(map.getContainer()).find('.leaflet-popup-content');
+            const $popup = $(leafletMap.getContainer()).find('.leaflet-popup-content');
 
             //A lot can happed between calling fetch and getting a response
             //Only update popup content if the popup context is still for this fetch

--- a/public/tooltip/visTooltip.js
+++ b/public/tooltip/visTooltip.js
@@ -86,10 +86,12 @@ define(function (require) {
               self.sirenMeta.vis.panelIndex
             );
 
-            etmVisNode.d.widgets.push({
-              id: self.visId,
-              panelIndex
-            });
+            if (_.has(etmVisNode, 'd.widgets')) {
+              etmVisNode.d.widgets.push({
+                id: self.visId,
+                panelIndex
+              });
+            }
 
             sirenMetaTooltip.vis.id = self.visId;
             sirenMetaTooltip.vis.panelIndex = panelIndex;

--- a/public/tooltip/visTooltip.js
+++ b/public/tooltip/visTooltip.js
@@ -5,6 +5,7 @@ import { SearchSourceProvider } from 'ui/courier/data_source/search_source';
 import { FilterBarQueryFilterProvider } from 'ui/filter_bar/query_filter';
 import { addSirenPropertyToVisOrSearch } from 'ui/kibi/components/dashboards360/add_property_to_vis_or_search.js';
 import { findItemByVisIdAndPanelIndex } from 'ui/kibi/components/dashboards360/lib/coat/find_item_by_vis_id_and_panel_index';
+import { findMainCoatNode } from 'ui/kibi/components/dashboards360/coat_tree';
 
 define(function (require) {
   return function VisTooltipFactory(
@@ -86,12 +87,19 @@ define(function (require) {
               self.sirenMeta.vis.panelIndex
             );
 
-            if (_.has(etmVisNode, 'd.widgets')) {
+            //if vis is not assigned in coat tree, assign popup to main node
+            if (!etmVisNode) {
+              const mainNode = findMainCoatNode(sirenMetaTooltip.coat.items);
+              mainNode.d.widgets.push({
+                id: self.visId,
+                panelIndex
+              });
+            } else if (_.has(etmVisNode, 'd.widgets')) {
               etmVisNode.d.widgets.push({
                 id: self.visId,
                 panelIndex
               });
-            }
+            };
 
             sirenMetaTooltip.vis.id = self.visId;
             sirenMetaTooltip.vis.panelIndex = panelIndex;

--- a/public/tooltip/visTooltip.js
+++ b/public/tooltip/visTooltip.js
@@ -58,12 +58,12 @@ define(function (require) {
           return geoFilter.rectFilter(self.fieldname, self.geotype, bounds.top_left, bounds.bottom_right);
         }
 
-        return function (feature, map) {
+        return function (feature, leafletMap) {
           if (!feature) return '';
           if (!self.$visEl) return 'initializing';
 
-          const width = Math.round(map.getSize().x * _.get(self.options, 'xRatio', 0.6));
-          const height = Math.round(map.getSize().y * _.get(self.options, 'yRatio', 0.6));
+          const width = Math.round(leafletMap.getSize().x * _.get(self.options, 'xRatio', 0.6));
+          const height = Math.round(leafletMap.getSize().y * _.get(self.options, 'yRatio', 0.6));
           const style = 'style="height: ' + height + 'px; width: ' + width + 'px;"';
           const loadHtml = '<div ' + style + '>Loading Visualization Data</div>';
 
@@ -110,7 +110,7 @@ define(function (require) {
               height: height
             });
 
-            const $popup = $(map.getContainer()).find('.leaflet-popup-content');
+            const $popup = $(leafletMap.getContainer()).find('.leaflet-popup-content');
 
             //A lot can happed between calling fetch and getting a response
             //Only update popup content if the popup context is still for this fetch

--- a/public/utils.js
+++ b/public/utils.js
@@ -135,15 +135,15 @@ define(function (require) {
      * anchor popups so content fits inside map bounds.
      *
      * @method popupOffset
-     * @param map {L.Map} Leaflet map
+     * @param leafletMap {L.Map} Leaflet map
      * @param content {String} String containing html popup content
      * @param latLng {L.LatLng} popup location
      * @return {L.Point} offset
      */
-    popupOffset: function (map, content, latLng) {
-      const mapWidth = map.getSize().x;
-      const mapHeight = map.getSize().y;
-      const popupPoint = map.latLngToContainerPoint(latLng);
+    popupOffset: function (leafletMap, content, latLng) {
+      const mapWidth = leafletMap.getSize().x;
+      const mapHeight = leafletMap.getSize().y;
+      const popupPoint = leafletMap.latLngToContainerPoint(latLng);
       //Create popup that is out of view to determine dimensions
       const popup = L.popup({
         autoPan: false,
@@ -153,7 +153,7 @@ define(function (require) {
       })
         .setLatLng(latLng)
         .setContent(content)
-        .openOn(map);
+        .openOn(leafletMap);
       const popupHeight = popup._contentNode.clientHeight;
       const popupWidth = popup._contentNode.clientWidth / 2;
 

--- a/public/utils.js
+++ b/public/utils.js
@@ -140,15 +140,17 @@ define(function (require) {
      * @param latLng {L.LatLng} popup location
      * @return {L.Point} offset
      */
-    popupOffset: function (leafletMap, content, latLng) {
+    popupOffset: function (leafletMap, content, latLng, popupDimensions) {
       const mapWidth = leafletMap.getSize().x;
       const mapHeight = leafletMap.getSize().y;
       const popupPoint = leafletMap.latLngToContainerPoint(latLng);
+      const maxHeight = _.get(popupDimensions, 'height', 'auto');
+      const maxWidth = _.get(popupDimensions, 'width', 'auto');
       //Create popup that is out of view to determine dimensions
       const popup = L.popup({
         autoPan: false,
-        maxHeight: 'auto',
-        maxWidth: 'auto',
+        maxHeight,
+        maxWidth,
         offset: new L.Point(mapWidth * -2, mapHeight * -2)
       })
         .setLatLng(latLng)

--- a/public/visController.js
+++ b/public/visController.js
@@ -202,15 +202,17 @@ define(function (require) {
     }
 
     function _doFitMapBoundsToData() {
-      const boundsHelper = new BoundsHelper(chartData.searchSource, getGeoField().fieldname);
-      boundsHelper.getBoundsOfEntireDataSelection($scope.vis)
-        .then(entireBounds => {
-          if (entireBounds) {
-            map.leafletMap.fitBounds(entireBounds);
-            //update uiState zoom so correct geohash precision will be used
-            $scope.vis.getUiState().set('mapZoom', map.leafletMap.getZoom());
-          };
-        });
+      if (_.has(chartData, 'searchSource')) {
+        const boundsHelper = new BoundsHelper(chartData.searchSource, getGeoField().fieldname);
+        boundsHelper.getBoundsOfEntireDataSelection($scope.vis)
+          .then(entireBounds => {
+            if (entireBounds) {
+              map.leafletMap.fitBounds(entireBounds);
+              //update uiState zoom so correct geohash precision will be used
+              $scope.vis.getUiState().set('mapZoom', map.leafletMap.getZoom());
+            };
+          });
+      }
     }
 
     function aggFilter(field) {

--- a/public/visController.js
+++ b/public/visController.js
@@ -206,9 +206,9 @@ define(function (require) {
       boundsHelper.getBoundsOfEntireDataSelection($scope.vis)
         .then(entireBounds => {
           if (entireBounds) {
-            map.map.fitBounds(entireBounds);
+            map.leafletMap.fitBounds(entireBounds);
             //update uiState zoom so correct geohash precision will be used
-            $scope.vis.getUiState().set('mapZoom', map.map.getZoom());
+            $scope.vis.getUiState().set('mapZoom', map.leafletMap.getZoom());
           };
         });
     }
@@ -607,7 +607,7 @@ define(function (require) {
     // ==       vis object      ==
     // ===========================
 
-    map.map.on('groupLayerControl:removeClickedLayer', function (e) {
+    map.leafletMap.on('groupLayerControl:removeClickedLayer', function (e) {
       $scope.vis.params.overlays.dragAndDropPoiLayers =
         _.filter($scope.vis.params.overlays.dragAndDropPoiLayers, function (dragAndDropPoiLayer) {
           return dragAndDropPoiLayer.searchIcon !== e.name;
@@ -615,25 +615,25 @@ define(function (require) {
     });
 
     // saving checkbox status to dashboard uiState
-    map.map.on('overlayadd', function (e) {
+    map.leafletMap.on('overlayadd', function (e) {
       map.saturateWMSTiles();
       $scope.vis.getUiState().set(e.name, !!e.name);
     });
-    map.map.on('overlayremove', function (e) {
+    map.leafletMap.on('overlayremove', function (e) {
       $scope.vis.getUiState().set(e.name, false);
     });
 
-    map.map.on('moveend', _.debounce(function setZoomCenter(ev) {
-      if (!map.map) return;
+    map.leafletMap.on('moveend', _.debounce(function setZoomCenter(ev) {
+      if (!map.leafletMap) return;
       if (map._hasSameLocation()) return;
 
       // update internal center and zoom references
-      map._mapCenter = map.map.getCenter();
+      map._mapCenter = map.leafletMap.getCenter();
       $scope.vis.getUiState().set('mapCenter', [
         _.round(map._mapCenter.lat, 5),
         _.round(map._mapCenter.lng, 5)
       ]);
-      $scope.vis.getUiState().set('mapZoom', map.map.getZoom());
+      $scope.vis.getUiState().set('mapZoom', map.leafletMap.getZoom());
 
       map._callbacks.mapMoveEnd({
         searchSource: $scope.searchSource,
@@ -642,11 +642,11 @@ define(function (require) {
       });
     }, 150, false));
 
-    map.map.on('zoomend', _.debounce(function () {
-      if (!map.map) return;
+    map.leafletMap.on('zoomend', _.debounce(function () {
+      if (!map.leafletMap) return;
       if (map._hasSameLocation()) return;
       if (!map._callbacks) return;
-      $scope.vis.getUiState().set('mapZoom', map.map.getZoom());
+      $scope.vis.getUiState().set('mapZoom', map.leafletMap.getZoom());
 
       map._callbacks.mapZoomEnd({
         searchSource: $scope.searchSource,
@@ -654,11 +654,11 @@ define(function (require) {
       });
     }, 150, false));
 
-    map.map.on('setview:fitBounds', function (e) {
+    map.leafletMap.on('setview:fitBounds', function (e) {
       _doFitMapBoundsToData();
     });
 
-    map.map.on('draw:created', function (e) {
+    map.leafletMap.on('draw:created', function (e) {
       const indexPatternId = getIndexPatternId();
       const field = getGeoField();
       const sirenMeta = getSirenMeta();
@@ -706,7 +706,7 @@ define(function (require) {
       }
     });
 
-    map.map.on('etm:select-feature', function (e) {
+    map.leafletMap.on('etm:select-feature', function (e) {
       map._callbacks.polygon({
         points: e.geojson.geometry.coordinates[0],
         field: getGeoField(),
@@ -714,7 +714,7 @@ define(function (require) {
       });
     });
 
-    map.map.on('toolbench:poiFilter', function (e) {
+    map.leafletMap.on('toolbench:poiFilter', function (e) {
       const poiLayers = [];
       Object.keys(map._poiLayers).forEach(function (key) {
         poiLayers.push(map._poiLayers[key]);

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -90,7 +90,7 @@ define(function (require) {
             point,
             { icon: markerIcon(color) }));
       });
-      this.map.addLayer(this._drawnItems);
+      this.leafletMap.addLayer(this._drawnItems);
       this._layerControl.addOverlay(this._drawnItems, 'Markers');
 
       //https://github.com/Leaflet/Leaflet.draw
@@ -122,16 +122,16 @@ define(function (require) {
       }
 
       this._drawControl = new L.Control.Draw(drawOptions);
-      this.map.addControl(this._drawControl);
+      this.leafletMap.addControl(this._drawControl);
 
-      this._toolbench = new LDrawToolbench(this.map, this._drawControl);
+      this._toolbench = new LDrawToolbench(this.leafletMap, this._drawControl);
     };
 
     TileMapMap.prototype._addSetViewControl = function () {
       if (this._setViewControl) return;
 
       this._setViewControl = new L.Control.SetView();
-      this.map.addControl(this._setViewControl);
+      this.leafletMap.addControl(this._setViewControl);
     };
 
     TileMapMap.prototype._addMousePositionControl = function () {
@@ -154,7 +154,7 @@ define(function (require) {
           }
         ]
       });
-      this.map.addControl(this._mousePositionControl);
+      this.leafletMap.addControl(this._mousePositionControl);
     };
 
     /**
@@ -179,7 +179,7 @@ define(function (require) {
       };
 
       // label.addTo(this.map);
-      this.map.addControl(label);
+      this.leafletMap.addControl(label);
     };
 
     /**
@@ -197,7 +197,7 @@ define(function (require) {
     };
 
     TileMapMap.prototype.updateSize = function () {
-      this.map.invalidateSize({
+      this.leafletMap.invalidateSize({
         debounceMoveend: true
       });
     };
@@ -206,13 +206,13 @@ define(function (require) {
       this.clearPOILayers();
       this.clearVectorLayers();
       this._destroyMapEvents();
-      if (this._label) this._label.removeFrom(this.map);
-      if (this._fitControl) this._fitControl.removeFrom(this.map);
-      if (this._drawControl) this._drawControl.remove(this.map);
+      if (this._label) this._label.removeFrom(this.leafletMap);
+      if (this._fitControl) this._fitControl.removeFrom(this.leafletMap);
+      if (this._drawControl) this._drawControl.remove(this.leafletMap);
       if (this._markers) this._markers.destroy();
-      syncMaps.remove(this.map);
-      this.map.remove();
-      this.map = undefined;
+      syncMaps.remove(this.leafletMap);
+      this.leafletMap.remove();
+      this.leafletMap = undefined;
     };
 
     TileMapMap.prototype.clearPOILayers = function () {
@@ -220,7 +220,7 @@ define(function (require) {
         const layer = this._poiLayers[key];
         layer.destroy();
         this._layerControl.removeLayer(layer);
-        this.map.removeLayer(layer);
+        this.leafletMap.removeLayer(layer);
       });
       this._poiLayers = {};
       if (this._toolbench) this._toolbench.removeTools();
@@ -231,7 +231,7 @@ define(function (require) {
         const layer = this._vectorOverlays[key];
         layer.destroy();
         this._layerControl.removeLayer(layer);
-        this.map.removeLayer(layer);
+        this.leafletMap.removeLayer(layer);
       });
       this._vectorOverlays = {};
       if (this._toolbench) this._toolbench.removeTools();
@@ -242,7 +242,7 @@ define(function (require) {
         if (overlay.type && overlay.type === 'WFS') {
           overlay.destroy();
           this._layerControl.removeLayer(overlay);
-          this.map.removeLayer(overlay);
+          this.leafletMap.removeLayer(overlay);
         }
         return overlay.type && overlay.type === 'WFS';
       });
@@ -257,9 +257,9 @@ define(function (require) {
       if (_.has(this._poiLayers, layerName)) {
         const layer = this._poiLayers[layerName];
         this._poiLayers[layerName].destroy();
-        isVisible = this.map.hasLayer(layer);
+        isVisible = this.leafletMap.hasLayer(layer);
         this._layerControl.removeLayer(layer);
-        this.map.removeLayer(layer);
+        this.leafletMap.removeLayer(layer);
         delete this._poiLayers[layerName];
       }
 
@@ -272,7 +272,7 @@ define(function (require) {
       }
 
       if (isVisible) {
-        this.map.addLayer(layer);
+        this.leafletMap.addLayer(layer);
       }
 
       const tooManyDocs = {
@@ -312,7 +312,7 @@ define(function (require) {
       }
 
       if (isVisible) {
-        this.map.addLayer(layer);
+        this.leafletMap.addLayer(layer);
       }
 
       this._vectorOverlays[layerName] = layer;
@@ -360,11 +360,11 @@ define(function (require) {
     TileMapMap.prototype.addFilters = function (filters) {
       let isVisible = false;
       if (this._filters) {
-        if (this.map.hasLayer(this._filters)) {
+        if (this.leafletMap.hasLayer(this._filters)) {
           isVisible = true;
         }
         this._layerControl.removeLayer(this._filters);
-        this.map.removeLayer(this._filters);
+        this.leafletMap.removeLayer(this._filters);
       }
 
       const style = {
@@ -386,7 +386,7 @@ define(function (require) {
       }
 
       if (isVisible) {
-        this.map.addLayer(this._filters);
+        this.leafletMap.addLayer(this._filters);
       }
 
 
@@ -397,9 +397,9 @@ define(function (require) {
       const prevState = {};
       Object.keys(this._wmsOverlays).forEach(key => {
         const layer = this._wmsOverlays[key];
-        prevState[key] = this.map.hasLayer(layer);
+        prevState[key] = this.leafletMap.hasLayer(layer);
         this._layerControl.removeLayer(layer);
-        this.map.removeLayer(layer);
+        this.leafletMap.removeLayer(layer);
       });
       this._wmsOverlays = {};
       return prevState;
@@ -416,7 +416,7 @@ define(function (require) {
 
       overlay.layerOptions = layerOptions;
 
-      if (layerOptions.isVisible) this.map.addLayer(overlay);
+      if (layerOptions.isVisible) this.leafletMap.addLayer(overlay);
 
 
       this._layerControl.addOverlay(overlay, name, '<b> WMS Overlays</b>');
@@ -443,7 +443,7 @@ define(function (require) {
     };
 
     TileMapMap.prototype.mapBounds = function () {
-      let bounds = this.map.getBounds();
+      let bounds = this.leafletMap.getBounds();
 
       //When map is not visible, there is no width or height.
       //Need to manually create bounds based on container width/height
@@ -453,8 +453,8 @@ define(function (require) {
           parent = parent.parentNode;
         }
 
-        const southWest = this.map.layerPointToLatLng(L.point(parent.clientWidth / 2 * -1, parent.clientHeight / 2 * -1));
-        const northEast = this.map.layerPointToLatLng(L.point(parent.clientWidth / 2, parent.clientHeight / 2));
+        const southWest = this.leafletMap.layerPointToLatLng(L.point(parent.clientWidth / 2 * -1, parent.clientHeight / 2 * -1));
+        const northEast = this.leafletMap.layerPointToLatLng(L.point(parent.clientWidth / 2, parent.clientHeight / 2));
         bounds = L.latLngBounds(southWest, northEast);
       }
       return bounds;
@@ -469,7 +469,7 @@ define(function (require) {
      */
     TileMapMap.prototype._createMarkers = function (options) {
       const MarkerType = markerTypes[this._markerType];
-      return new MarkerType(this.map, this._geoJson, this._layerControl, options);
+      return new MarkerType(this.leafletMap, this._geoJson, this._layerControl, options);
     };
 
     TileMapMap.prototype.unfixMapTypeTooltips = function () {
@@ -491,11 +491,11 @@ define(function (require) {
       }
 
       //update map options based on new attributes
-      if (this.map) {
+      if (this.leafletMap) {
         if (this._attr.scrollWheelZoom) {
-          this.map.scrollWheelZoom.enable();
+          this.leafletMap.scrollWheelZoom.enable();
         } else {
-          this.map.scrollWheelZoom.disable();
+          this.leafletMap.scrollWheelZoom.disable();
         }
       }
     };
@@ -518,24 +518,24 @@ define(function (require) {
       ];
 
       allEvents.forEach(event => {
-        this.map.off(event);
+        this.leafletMap.off(event);
       });
     };
 
     TileMapMap.prototype._attachEvents = function () {
       const self = this;
 
-      this.map.on('groupLayerControl:removeClickedLayer', (e) => {
+      this.leafletMap.on('groupLayerControl:removeClickedLayer', (e) => {
         const layerName = e.name;
         if (_.has(this._poiLayers, layerName)) {
           const layer = this._poiLayers[layerName];
           this._poiLayers[layerName].destroy();
-          this.map.removeLayer(layer);
+          this.leafletMap.removeLayer(layer);
           delete this._poiLayers[layerName];
         }
       });
 
-      this.map.on('etm:select-feature-vector', function (e) {
+      this.leafletMap.on('etm:select-feature-vector', function (e) {
         self._callbacks.polygonVector({
           args: e.args,
           params: self._attr,
@@ -544,29 +544,29 @@ define(function (require) {
       });
 
       //stop popups appearing when drawing has started
-      this.map.on('draw:drawstart', function (e) {
+      this.leafletMap.on('draw:drawstart', function (e) {
         this.disablePopups = true;
       });
 
       //start popups appearing finished drawing
-      this.map.on('draw:drawstop', function (e) {
+      this.leafletMap.on('draw:drawstop', function (e) {
         this.disablePopups = false;
       });
 
-      this.map.on('draw:deleted', function (e) {
+      this.leafletMap.on('draw:deleted', function (e) {
         self._callbacks.deleteMarkers({
           chart: self._chartData,
           deletedLayers: e.layers,
         });
       });
 
-      this.map.on('overlayadd', function (e) {
+      this.leafletMap.on('overlayadd', function (e) {
         if (self._markers && e.name === 'Aggregation') {
           self._markers.show();
         }
       });
 
-      this.map.on('overlayremove', function (e) {
+      this.leafletMap.on('overlayremove', function (e) {
         if (self._markers && e.name === 'Aggregation') {
           self._markers.hide();
         }
@@ -576,12 +576,12 @@ define(function (require) {
     TileMapMap.prototype._hasSameLocation = function () {
       const oldLat = this._mapCenter.lat.toFixed(5);
       const oldLon = this._mapCenter.lng.toFixed(5);
-      const newLat = this.map.getCenter().lat.toFixed(5);
-      const newLon = this.map.getCenter().lng.toFixed(5);
+      const newLat = this.leafletMap.getCenter().lat.toFixed(5);
+      const newLon = this.leafletMap.getCenter().lng.toFixed(5);
       let isSame = false;
       if (oldLat === newLat
         && oldLon === newLon
-        && this.map.getZoom() === this._mapZoom) {
+        && this.leafletMap.getZoom() === this._mapZoom) {
         isSame = true;
       }
       return isSame;
@@ -596,11 +596,11 @@ define(function (require) {
         this._tileLayer.remove();
         this._tileLayer = L.tileLayer(mapTiles.url, mapTiles.options);
       }
-      this._tileLayer.addTo(this.map);
+      this._tileLayer.addTo(this.leafletMap);
     };
 
     TileMapMap.prototype._createMap = function (mapOptions) {
-      if (this.map) this.destroy();
+      if (this.leafletMap) this.destroy();
 
       // Use WMS compliant server, if not enabled, use OSM mapTiles as default
       if (this._attr.wms && this._attr.wms.enabled) {
@@ -612,23 +612,23 @@ define(function (require) {
       mapOptions.center = this._mapCenter;
       mapOptions.zoom = this._mapZoom;
 
-      this.map = L.map(this._container, mapOptions);
+      this.leafletMap = L.map(this._container, mapOptions);
 
       // add base layer based on above logic and decide saturation based on saved settings
-      this._tileLayer.addTo(this.map);
+      this._tileLayer.addTo(this.leafletMap);
 
       this.saturateTiles(this._attr.isDesaturated);
 
       const options = { groupCheckboxes: true };
       this._layerControl = L.control.groupedLayers();
-      this._layerControl.addTo(this.map);
+      this._layerControl.addTo(this.leafletMap);
 
       this._addSetViewControl();
       this._addDrawControl();
       this._addMousePositionControl();
-      L.control.measureScale().addTo(this.map);
+      L.control.measureScale().addTo(this.leafletMap);
       this._attachEvents();
-      if (mapOptions.syncMap) syncMaps.add(this.map);
+      if (mapOptions.syncMap) syncMaps.add(this.leafletMap);
     };
 
     /**
@@ -636,11 +636,11 @@ define(function (require) {
      * even those NOT currently within map canvas extent
      *
      * @method _fitBounds
-     * @param map {Leaflet Object}
+     * @param leafletMap {Leaflet Object}
      * @return {boolean}
      */
     TileMapMap.prototype.fitBounds = function (entireBounds) {
-      this.map.fitBounds(entireBounds);
+      this.leafletMap.fitBounds(entireBounds);
     };
     return TileMapMap;
   };

--- a/public/vislib/marker_types/base_marker.js
+++ b/public/vislib/marker_types/base_marker.js
@@ -10,13 +10,13 @@ define(function (require) {
     /**
      * Base map marker overlay, all other markers inherit from this class
      *
-     * @param map {Leaflet Object}
+     * @param leafletMap {Leaflet Object}
      * @param geoJson {geoJson Object}
      * @param params {Object}
      */
-    function BaseMarker(map, geoJson, layerControl, params) {
+    function BaseMarker(leafletMap, geoJson, layerControl, params) {
       this.uiState = params.uiState;
-      this.map = map; // this is the leaflet map (i.e. L.map())
+      this.leafletMap = leafletMap;
       this.geoJson = geoJson;
       this.layerControl = layerControl;
       this.popups = [];
@@ -110,7 +110,7 @@ define(function (require) {
         return $div.get(0);
       };
 
-      if (self.isVisible) self._legend.addTo(self.map);
+      if (self.isVisible) self._legend.addTo(self.leafletMap);
     };
 
     BaseMarker.prototype.removeLegend = function () {
@@ -120,7 +120,7 @@ define(function (require) {
 
       if (this._legend) {
         if (this._legend._map) {
-          this.map.removeControl(this._legend);
+          this.leafletMap.removeControl(this._legend);
         }
         this._legend = undefined;
       }
@@ -164,7 +164,7 @@ define(function (require) {
 
       self._popupMouseOut = function (e) {
         // detach the event
-        L.DomEvent.off(self.map._popup, 'mouseout', self._popupMouseOut, self);
+        L.DomEvent.off(self.leafletMap._popup, 'mouseout', self._popupMouseOut, self);
 
         // get the element that the mouse hovered onto
         const target = e.toElement || e.relatedTarget;
@@ -208,7 +208,7 @@ define(function (require) {
 
           // check to see if the element is a popup
           if (self._getParent(target, 'leaflet-popup')) {
-            L.DomEvent.on(self.map._popup._container, 'mouseout', self._popupMouseOut, self);
+            L.DomEvent.on(self.leafletMap._popup._container, 'mouseout', self._popupMouseOut, self);
             return true;
           }
 
@@ -241,7 +241,7 @@ define(function (require) {
      */
     BaseMarker.prototype.destroy = function () {
       const state = {
-        isVisible: this._markerGroup && this.map.hasLayer(this._markerGroup),
+        isVisible: this._markerGroup && this.leafletMap.hasLayer(this._markerGroup),
         threshold: {
           floor: _.get(this.geoJson, 'properties.allmin', 0),
           ceil: _.get(this.geoJson, 'properties.allmax', 1),
@@ -263,8 +263,8 @@ define(function (require) {
       // remove marker layer from map
       if (this._markerGroup) {
         this.layerControl.removeLayer(this._markerGroup);
-        if (this.map.hasLayer(this._markerGroup)) {
-          this.map.removeLayer(this._markerGroup);
+        if (this.leafletMap.hasLayer(this._markerGroup)) {
+          this.leafletMap.removeLayer(this._markerGroup);
         }
         this._markerGroup = undefined;
       }
@@ -275,13 +275,13 @@ define(function (require) {
     BaseMarker.prototype.hide = function () {
       this._stopLoadingGeohash();
       if (this._legend) {
-        this.map.removeControl(this._legend);
+        this.leafletMap.removeControl(this._legend);
       }
     };
 
     BaseMarker.prototype.show = function () {
       if (this._legend) {
-        this._legend.addTo(this.map);
+        this._legend.addTo(this.leafletMap);
       }
     };
 
@@ -296,7 +296,7 @@ define(function (require) {
         this.isVisible = false;
       }
 
-      if (this.isVisible) this.map.addLayer(this._markerGroup);
+      if (this.isVisible) this.leafletMap.addLayer(this._markerGroup);
 
       if (_.has(this, 'geoJson.features.length') && this.geoJson.features.length >= 1) {
         this.addLegend();
@@ -367,12 +367,12 @@ define(function (require) {
      * @return undefined
      */
     BaseMarker.prototype._showTooltip = function (feature, latLng) {
-      if (!this.map) return;
+      if (!this.leafletMap) return;
       const lat = _.get(feature, 'geometry.coordinates.1');
       const lng = _.get(feature, 'geometry.coordinates.0');
       latLng = latLng || L.latLng(lat, lng);
 
-      const content = this._tooltipFormatter(feature, this.map);
+      const content = this._tooltipFormatter(feature, this.leafletMap);
 
       if (!content) return;
       this._createTooltip(content, latLng);
@@ -389,11 +389,11 @@ define(function (require) {
         className: className,
         maxHeight: 'auto',
         maxWidth: 'auto',
-        offset: utils.popupOffset(this.map, content, latLng)
+        offset: utils.popupOffset(this.leafletMap, content, latLng)
       })
         .setLatLng(latLng)
         .setContent(content)
-        .openOn(this.map);
+        .openOn(this.leafletMap);
     };
 
     /**
@@ -403,9 +403,9 @@ define(function (require) {
      * @return undefined
      */
     BaseMarker.prototype._hidePopup = function () {
-      if (!this.map) return;
+      if (!this.leafletMap) return;
 
-      this.map.closePopup();
+      this.leafletMap.closePopup();
     };
 
     BaseMarker.prototype._createSpinControl = function () {
@@ -425,13 +425,13 @@ define(function (require) {
       });
 
       this._spinControl = new SpinControl();
-      this.map.addControl(this._spinControl);
+      this.leafletMap.addControl(this._spinControl);
     };
 
     BaseMarker.prototype._removeSpinControl = function () {
       if (!this._spinControl) return;
 
-      this.map.removeControl(this._spinControl);
+      this.leafletMap.removeControl(this._spinControl);
       this._spinControl = null;
     };
 

--- a/public/vislib/marker_types/geohash_grid.js
+++ b/public/vislib/marker_types/geohash_grid.js
@@ -8,12 +8,12 @@ define(function (require) {
     /**
      * Map overlay: rectangles that show the geohash grid bounds
      *
-     * @param map {Leaflet Object}
+     * @param leafletMap {Leaflet Object}
      * @param geoJson {geoJson Object}
      * @param params {Object}
      */
     _.class(GeohashGridMarker).inherits(BaseMarker);
-    function GeohashGridMarker(map, geoJson, params) {
+    function GeohashGridMarker(leafletMap, geoJson, params) {
       GeohashGridMarker.Super.apply(this, arguments);
 
       this._createMarkerGroup({

--- a/public/vislib/marker_types/heatmap.js
+++ b/public/vislib/marker_types/heatmap.js
@@ -9,12 +9,12 @@ define(function (require) {
     /**
      * Map overlay: canvas layer with leaflet.heat plugin
      *
-     * @param map {Leaflet Object}
+     * @param leafletMap {Leaflet Object}
      * @param geoJson {geoJson Object}
      * @param params {Object}
      */
     _.class(HeatmapMarker).inherits(BaseMarker);
-    function HeatmapMarker(map, geoJson, params) {
+    function HeatmapMarker(leafletMap, geoJson, params) {
       const self = this;
       this._disableTooltips = false;
       HeatmapMarker.Super.apply(this, arguments);
@@ -45,10 +45,10 @@ define(function (require) {
     };
 
     HeatmapMarker.prototype.unfixTooltips = function () {
-      this.map.off('mousemove');
-      this.map.off('mouseout');
-      this.map.off('mousedown');
-      this.map.off('mouseup');
+      this.leafletMap.off('mousemove');
+      this.leafletMap.off('mouseout');
+      this.leafletMap.off('mousedown');
+      this.leafletMap.off('mouseup');
     };
 
     HeatmapMarker.prototype._fixTooltips = function () {
@@ -59,15 +59,15 @@ define(function (require) {
       });
 
       if (!this._disableTooltips && this._attr.addTooltip) {
-        this.map.on('mousemove', debouncedMouseMoveLocation);
-        this.map.on('mouseout', function () {
-          self.map.closePopup();
+        this.leafletMap.on('mousemove', debouncedMouseMoveLocation);
+        this.leafletMap.on('mouseout', function () {
+          self.leafletMap.closePopup();
         });
-        this.map.on('mousedown', function () {
+        this.leafletMap.on('mousedown', function () {
           self._disableTooltips = true;
-          self.map.closePopup();
+          self.leafletMap.closePopup();
         });
-        this.map.on('mouseup', function () {
+        this.leafletMap.on('mouseup', function () {
           self._disableTooltips = false;
         });
       }
@@ -75,7 +75,7 @@ define(function (require) {
       function mouseMoveLocation(e) {
         const latlng = e.latlng;
 
-        this.map.closePopup();
+        this.leafletMap.closePopup();
 
         // unhighlight all svgs
         d3.selectAll('path.geohash', this.chartEl).classed('geohash-hover', false);
@@ -163,7 +163,7 @@ define(function (require) {
         .domain([1, 4, 7, 10, 13, 16, 18])
         .range([1000000, 300000, 100000, 15000, 2000, 150, 50]);
 
-      const proximity = zoomScale(this.map.getZoom());
+      const proximity = zoomScale(this.leafletMap.getZoom());
       const distance = latlng.distanceTo(featureLatLng);
 
       // maxLngDif is max difference in longitudes

--- a/public/vislib/marker_types/scaled_circles.js
+++ b/public/vislib/marker_types/scaled_circles.js
@@ -8,19 +8,19 @@ define(function (require) {
     /**
      * Map overlay: circle markers that are scaled to illustrate values
      *
-     * @param map {Leaflet Object}
+     * @param leafletMap {Leaflet Object}
      * @param mapData {geoJson Object}
      * @param params {Object}
      */
     _.class(ScaledCircleMarker).inherits(BaseMarker);
-    function ScaledCircleMarker(map, geoJson, params) {
+    function ScaledCircleMarker(leafletMap, geoJson, params) {
       const self = this;
       ScaledCircleMarker.Super.apply(this, arguments);
 
       // Earth circumference in meters
       const earthCircumference = 40075017;
-      const mapZoom = map.getZoom();
-      const latitudeRadians = map.getCenter().lat * (Math.PI / 180);
+      const mapZoom = leafletMap.getZoom();
+      const latitudeRadians = leafletMap.getCenter().lat * (Math.PI / 180);
       this._metersPerPixel = earthCircumference * Math.cos(latitudeRadians) / Math.pow(2, mapZoom + 8);
 
       this._createMarkerGroup({


### PR DESCRIPTION
Addressing https://github.com/sirensolutions/kibi-internal/issues/11579. Needs to be rebased with master after #145 is merged.

I went through the entire repo, taking notes on what features would be affected by this change. The below have been manually tested:
- Aggregation legend and slider
- Aggregation tooltips (both on mouseover and mouseout)
- All events with and without data present on map i.e. set view, fitdata, autofitdata, filter creation
- Applied filters draw and can be toggled on layer control
- WMS and WFS work
- Destroy method don't produce console errors
- Map move end and map zoom end events

Also included in this fix are small cases where there were console errors relating to some recent features. 
