### PR TITLE
Adding geojson support for wfs requests

### DIFF
--- a/public/directives/wfsOverlay.html
+++ b/public/directives/wfsOverlay.html
@@ -37,10 +37,11 @@
   <div class="vis-option-item form-group">
     <label>
       Output Format <kbn-info
-        info="The format your server should respond with, e.g. geojson for ArcGis Server. Note - json is the default">
+        info="The format your server should respond with">
       </kbn-info>
     </label>
-    <input type="text" class="form-control" ng-model="layer.formatOptions" name="layer.formatOptions" />
+    <select class="form-control" placeholder="Click to select WFS layer(s)..." ng-model="layer.formatOptions"
+    ng-options="outputFormatType for outputFormatType in ['json', 'geojson']"></select>
   </div>
   <div class="form-group">
     <label>Popup Content <kbn-info

--- a/public/directives/wfsOverlay.html
+++ b/public/directives/wfsOverlay.html
@@ -3,13 +3,13 @@
     <label>
       Layer Name <kbn-info info="Layer name displayed in map layer control."></kbn-info>
     </label>
-    <input required type="text" class="form-control" ng-model="layer.displayName" name="displayName">
+    <input required type="text" class="form-control" ng-model="layer.displayName" name="displayName" />
   </div>
   <div class="vis-option-item form-group">
     <label>
       Url
     </label>
-    <input required type="text" class="form-control" name="url" ng-model="layer.url">
+    <input required type="text" class="form-control" name="url" ng-model="layer.url" />
   </div>
 
   <div ng-if="layer.wfsCapabilitiesSwitch === false">
@@ -18,7 +18,7 @@
         info="A comma seperated list of layers to use. If you have entered a valid (CORs enabled) WFS Url, a UI-based menu will appear for WFS layer(s) selection and ordering">
       </kbn-info>
     </label>
-    <input required type="text" class="form-control" ng-model="layer.layers">
+    <input required type="text" class="form-control" ng-model="layer.layers" />
   </div>
   <!-- OR-->
   <div class="vis-option-item form-group" ng-if="layer.wfsCapabilitiesSwitch === true">
@@ -34,11 +34,19 @@
     </label>
     <input minicolors ng-model="layer.color" type="text" class="form-control" name="color" />
   </div>
+  <div class="vis-option-item form-group">
+    <label>
+      Output Format <kbn-info
+        info="The format your server should respond with, e.g. geojson for ArcGis Server. Note - json is the default">
+      </kbn-info>
+    </label>
+    <input type="text" class="form-control" ng-model="layer.formatOptions" name="layer.formatOptions" />
+  </div>
   <div class="form-group">
     <label>Popup Content <kbn-info
         info="A comma seperated list of fields to use. They will appear in the order they are written">
       </kbn-info>
     </label>
-    <input type="text" class="form-control" ng-model="layer.popupFields">
+    <input type="text" class="form-control" ng-model="layer.popupFields" />
   </div>
 </div>

--- a/public/directives/wfsOverlay.html
+++ b/public/directives/wfsOverlay.html
@@ -37,7 +37,7 @@
   <div class="vis-option-item form-group">
     <label>
       Output Format <kbn-info
-        info="The format your server should respond with">
+        info="The format your server responds with, e.g. geojson for ArcGis Server">
       </kbn-info>
     </label>
     <select class="form-control" placeholder="Click to select WFS layer(s)..." ng-model="layer.formatOptions"

--- a/public/directives/wfsOverlay.js
+++ b/public/directives/wfsOverlay.js
@@ -4,7 +4,11 @@ import { parseString } from 'xml2js';
 import uuid from 'uuid';
 
 define(function (require) {
-  module.directive('wfsOverlay', function (indexPatterns, $http) {
+  module.directive('wfsOverlay', function (indexPatterns, $http, createNotifier) {
+
+    const notify = createNotifier({
+      location: 'Enhanced Coordinate Map'
+    });
 
     return {
       restrict: 'E',
@@ -120,7 +124,7 @@ define(function (require) {
           }
         })
         .catch(err => {
-          console.warn('An issue was encountered returning a layers list from WFS. Verify your ' +
+          notify.warning('An issue was encountered returning a layers list from WFS. Verify your ' +
             'WFS url (' + err.config.url + ') is correct, has layers present and WFS is CORs enabled for this domain.');
         });
     }

--- a/public/directives/wmsOverlay.html
+++ b/public/directives/wmsOverlay.html
@@ -65,7 +65,7 @@
   </div>
   <div class="vis-option-item form-group">
     <label>
-      Format Options
+      Output Format
     </label>
     <input type="text" class="form-control" ng-model="layer.formatOptions" name="layer.formatOptions">
   </div>

--- a/public/visController.js
+++ b/public/visController.js
@@ -25,7 +25,7 @@ define(function (require) {
     kibiState, savedSearches, savedDashboards, dashboardGroups,
     $scope, $rootScope, $element, $timeout, joinExplanation,
     Private, courier, config, getAppState, indexPatterns, $http, $injector,
-    timefilter) {
+    timefilter, createNotifier) {
     const buildChartData = Private(VislibVisTypeBuildChartDataProvider);
     const queryFilter = Private(FilterBarQueryFilterProvider);
     const callbacks = Private(require('plugins/enhanced_tilemap/callbacks'));
@@ -51,6 +51,10 @@ define(function (require) {
     };
 
     $scope.flags = {};
+
+    const notify = createNotifier({
+      location: 'Enhanced Coordinate Map'
+    });
 
     backwardsCompatible.updateParams($scope.vis.params);
     createDragAndDropPoiLayers();
@@ -414,18 +418,31 @@ define(function (require) {
         return;
       }
       _.each($scope.vis.params.overlays.wfsOverlays, wfsOverlay => {
-
+        const formatOption = wfsOverlay.formatOptions ? wfsOverlay.formatOptions : 'json';
         const options = {
           color: _.get(wfsOverlay, 'color', '#10aded'),
           popupFields: _.get(wfsOverlay, 'popupFields', ''),
           layerGroup: 'WFS Overlays'
         };
-        const getFeatureRequest = `${wfsOverlay.url}request=GetFeature&typeNames=${wfsOverlay.layers}&outputFormat=json`;
 
-        return $http.get(getFeatureRequest)
-          .then(resp => {
-            initVectorLayer(wfsOverlay.id, wfsOverlay.displayName, resp.data, options);
-          });
+        if (['geojson', 'json'].includes(formatOption)) {
+          const getFeatureRequest = `${wfsOverlay.url}request=GetFeature&typeNames=${wfsOverlay.layers}&outputFormat=${formatOption}`;
+
+          return $http.get(getFeatureRequest)
+            .then(resp => {
+              initVectorLayer(wfsOverlay.id, wfsOverlay.displayName, resp.data, options);
+            })
+            .catch(() => {
+              notify.error(`An issue was encountered returning ${wfsOverlay.layers} from WFS request. Please ensure: 
+              - url ( ${wfsOverlay.url} ) is correct and has layers present, 
+              - ${formatOption} is an allowed output format
+              - WFS is CORs enabled for this domain`);
+              map.clearLayerById(map.vectorOverlays, wfsOverlay.id);
+            });
+        } else {
+          notify.error(`Unsupported Output Format: ${formatOption}`);
+          map.clearLayerById(map.vectorOverlays, wfsOverlay.id);
+        }
       });
     }
 

--- a/public/visController.js
+++ b/public/visController.js
@@ -418,31 +418,26 @@ define(function (require) {
         return;
       }
       _.each($scope.vis.params.overlays.wfsOverlays, wfsOverlay => {
-        const formatOption = wfsOverlay.formatOptions ? wfsOverlay.formatOptions : 'json';
         const options = {
           color: _.get(wfsOverlay, 'color', '#10aded'),
           popupFields: _.get(wfsOverlay, 'popupFields', ''),
           layerGroup: 'WFS Overlays'
         };
 
-        if (['geojson', 'json'].includes(formatOption)) {
-          const getFeatureRequest = `${wfsOverlay.url}request=GetFeature&typeNames=${wfsOverlay.layers}&outputFormat=${formatOption}`;
+        const getFeatureRequest = `${wfsOverlay.url}request=GetFeature&typeNames=
+        ${wfsOverlay.layers}&outputFormat=${wfsOverlay.formatOptions}`;
 
-          return $http.get(getFeatureRequest)
-            .then(resp => {
-              initVectorLayer(wfsOverlay.id, wfsOverlay.displayName, resp.data, options);
-            })
-            .catch(() => {
-              notify.error(`An issue was encountered returning ${wfsOverlay.layers} from WFS request. Please ensure: 
+        return $http.get(getFeatureRequest)
+          .then(resp => {
+            initVectorLayer(wfsOverlay.id, wfsOverlay.displayName, resp.data, options);
+          })
+          .catch(() => {
+            notify.error(`An issue was encountered returning ${wfsOverlay.layers} from WFS request. Please ensure: 
               - url ( ${wfsOverlay.url} ) is correct and has layers present, 
-              - ${formatOption} is an allowed output format
+              - ${wfsOverlay.formatOptions} is an allowed output format
               - WFS is CORs enabled for this domain`);
-              map.clearLayerById(map.vectorOverlays, wfsOverlay.id);
-            });
-        } else {
-          notify.error(`Unsupported Output Format: ${formatOption}`);
-          map.clearLayerById(map.vectorOverlays, wfsOverlay.id);
-        }
+            map.clearLayerById(map.vectorOverlays, wfsOverlay.id);
+          });
       });
     }
 


### PR DESCRIPTION
A UI change to allow any outputFormat type to be specified. The WFS feature currently supports json or geojson types however and warning messages will be generated if 

- another format is specified
- the server doesn't provide a valid response

![SupportForGeoJsonAndJsonWFSTypes](https://user-images.githubusercontent.com/36197976/73067035-888ebf00-3e9f-11ea-8f7e-61daa2b5de64.gif)
