### PR TITLE
[WIP] - Desaturating non-tiled WMS layers

### DIFF
--- a/public/directives/wfsOverlay.html
+++ b/public/directives/wfsOverlay.html
@@ -40,7 +40,7 @@
         info="The format your server responds with, e.g. geojson for ArcGis Server">
       </kbn-info>
     </label>
-    <select class="form-control" placeholder="Click to select WFS layer(s)..." ng-model="layer.formatOptions"
+    <select required class="form-control" ng-model="layer.formatOptions"
     ng-options="outputFormatType for outputFormatType in ['json', 'geojson']"></select>
   </div>
   <div class="form-group">

--- a/public/directives/wfsOverlay.js
+++ b/public/directives/wfsOverlay.js
@@ -97,7 +97,7 @@ define(function (require) {
 
 
     function getWFSLayerList(url) {
-      const getCapabilitiesRequest = url + 'request=GetCapabilities';
+      const getCapabilitiesRequest = url + '/ows?service=wfs&version=1.1.0&request=GetCapabilities';
 
       return $http.get(getCapabilitiesRequest)
         .then(resp => {

--- a/public/directives/wmsOverlay.js
+++ b/public/directives/wmsOverlay.js
@@ -3,7 +3,11 @@ import { parseString } from 'xml2js';
 import uuid from 'uuid';
 
 define(function (require) {
-  module.directive('wmsOverlay', function (indexPatterns, $http) {
+  module.directive('wmsOverlay', function (indexPatterns, $http, createNotifier) {
+
+    const notify = createNotifier({
+      location: 'Enhanced Coordinate Map'
+    });
 
     return {
       restrict: 'E',
@@ -109,7 +113,7 @@ define(function (require) {
 
 
     function getWMSLayerList(url) {
-      const getCapabilitiesRequest = url + 'service=wms&request=GetCapabilities';
+      const getCapabilitiesRequest = url + '/ows?service=wms&version=1.1.1&request=GetCapabilities';
 
       return $http.get(getCapabilitiesRequest)
         .then(resp => {
@@ -123,8 +127,8 @@ define(function (require) {
                 }
 
                 //handles case(s) where there are no layer names returned from the WMS
-                if (result.WMS_Capabilities.Capability[0].Layer[0].Layer) {
-                  const wmsLayerNames = result.WMS_Capabilities.Capability[0].Layer[0].Layer.map(layer => layer.Name[0]);
+                if (result.WMT_MS_Capabilities.Capability[0].Layer[0].Layer) {
+                  const wmsLayerNames = result.WMT_MS_Capabilities.Capability[0].Layer[0].Layer.map(layer => layer.Name[0]);
                   resolve(wmsLayerNames);
                 } else {
                   resolve([]);
@@ -134,7 +138,7 @@ define(function (require) {
           }
         })
         .catch(err => {
-          console.warn('An issue was encountered returning a layers list from WMS. Verify your ' +
+          notify.warning('An issue was encountered returning a layers list from WMS. Verify your ' +
             'WMS url (' + err.config.url + ') is correct, has layers present and WMS is CORs enabled for this domain.');
         });
     }

--- a/public/vector.js
+++ b/public/vector.js
@@ -51,7 +51,7 @@ define(function () {
         });
         layer = new L.FeatureGroup(markers);
         layer.destroy = () => markers.forEach(self._removeMouseEventsPoint);
-
+        layer.displayName = `${options.displayName} <i class="fas fa-map-marker" style="color:${options.color};"></i>`;
       } else if ('Polygon' === geometry.type ||
         'MultiPolygon' === geometry.type) {
         const shapes = _.map(self._geoJsonCollection.features, (feature) => {
@@ -116,6 +116,7 @@ define(function () {
             }
           });
         };
+        layer.displayName = `${options.displayName} <i class="far fa-stop" style="color:${options.color};"></i>`;
       } else {
         console.warn('Unexpected feature geo type: ' + geometry.type);
       }

--- a/public/vis.less
+++ b/public/vis.less
@@ -203,7 +203,7 @@
 
   //non-tiled layer
   div.leaflet-image-layer.no-filter {
-    filter: grayscale(80%)
+    filter: grayscale(80%);
   }
   //tiled layer
   div.leaflet-layer.no-filter>div.leaflet-tile-container>img.leaflet-tile {

--- a/public/vis.less
+++ b/public/vis.less
@@ -201,6 +201,11 @@
     }
   }
 
+  //non-tiled layer
+  div.leaflet-image-layer.no-filter {
+    filter: grayscale(80%)
+  }
+  //tiled layer
   div.leaflet-layer.no-filter>div.leaflet-tile-container>img.leaflet-tile {
     filter: none !important;
   }

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -190,14 +190,22 @@ define(function (require) {
     /**
      * remove css class for desat filters on map tiles
      *
-     * @method saturateTiles
+     * @method saturateTile
      * @return undefined
      */
-    TileMapMap.prototype.saturateTiles = function (isDesaturated) {
+    TileMapMap.prototype.saturateTile = function (isDesaturated, overlay) {
       if (isDesaturated) {
-        $(this._tileLayer.getContainer()).removeClass('no-filter');
+        if (overlay instanceof L.NonTiledLayer) {
+          $(overlay._div).addClass('no-filter');
+        } else {
+          $(overlay.getContainer()).removeClass('no-filter');
+        }
       } else {
-        $(this._tileLayer.getContainer()).addClass('no-filter');
+        if (overlay instanceof L.NonTiledLayer) {
+          $(overlay._div).removeClass('no-filter');
+        } else {
+          $(overlay.getContainer()).addClass('no-filter');
+        }
       }
     };
 
@@ -392,15 +400,9 @@ define(function (require) {
 
       if (layerOptions.isVisible) this.leafletMap.addLayer(overlay);
 
-
       this._layerControl.addOverlay(overlay, name, '<b> WMS Overlays</b>');
       this.wmsOverlays[id] = overlay;
-
-      if (this._attr.isDesaturated) {
-        $(overlay.getContainer()).removeClass('no-filter');
-      } else {
-        $(overlay.getContainer()).addClass('no-filter');
-      }
+      this.saturateTile(this._attr.isDesaturated, overlay);
     };
 
     TileMapMap.prototype.saturateWMSTiles = function () {
@@ -408,11 +410,7 @@ define(function (require) {
         if (!this.wmsOverlays.hasOwnProperty(key)) {
           continue;
         }
-        if (this._attr.isDesaturated) {
-          $(this.wmsOverlays[key].getContainer()).removeClass('no-filter');
-        } else {
-          $(this.wmsOverlays[key].getContainer()).addClass('no-filter');
-        }
+        this.saturateTile(this._attr.isDesaturated, this.wmsOverlays[key]);
       }
     };
 
@@ -579,7 +577,7 @@ define(function (require) {
       // add base layer based on above logic and decide saturation based on saved settings
       this._tileLayer.addTo(this.leafletMap);
 
-      this.saturateTiles(this._attr.isDesaturated);
+      this.saturateTile(this._attr.isDesaturated, this._tileLayer);
 
       this._layerControl = L.control.groupedLayers(null, null, { groupCheckboxes: true });
       this._layerControl.addTo(this.leafletMap);


### PR DESCRIPTION
Layer labelling should be fixed. Pay attention to Texas and observe that the state name is repeated multiple times. When I select non-tiled layer, observe that the label is specified just once: 

![NonTiledLayerFixingLabelling](https://user-images.githubusercontent.com/36197976/74754302-550a3f00-5269-11ea-9cbf-6dc0e2ddd8d8.gif)

I also adjusted the requests to WMS and WFS. Although they worked for GeoServer previously, they should be robust enough to work for any type of WMS/WFS server now. I've asked Tom in PAX to verify two links that I've tailored for their system, if all well, happy to merge this.
