### PR TITLE
Remove npm from node_modules after installing dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,15 +149,22 @@ task installGruntGlobally(type: NpmTask) {
     args = ['install', '-g', 'grunt']
 }
 
-/**
- * Task to execute `npm ci`
- */
-task npmCi(type: NpmTask, dependsOn: [installGruntGlobally]) {
+///////////////////////////////////////////////////
+//                                               //
+//           Install Packages                    //
+//                                               //
+///////////////////////////////////////////////////
+
+task preNpmCi(type: NpmTask, dependsOn: [installGruntGlobally]) {
     execOverrides {
         it.workingDir = projectDir
     }
 
     setArgs( ['ci'] )
+}
+
+task npmCi(type: Delete, dependsOn: [preNpmCi]) {
+    delete "${projectDir}/node_modules/.bin/npm", "${projectDir}/node_modules/npm"
 }
 
 
@@ -228,7 +235,6 @@ task gulpTestDev(type: GulpTask) {
 
 // run npm install
 gulpTestDev.dependsOn 'npmCi'
-
 
 ///////////////////////////////////////////////////
 //                                               //


### PR DESCRIPTION
…ndencies

semantic-release has npm as a dependency, so after running gulpTest `node_modules` contains npm.

When running `gulpPackage`, node will use the `npm` installed in `node_modules`, which will destroy itself when removing `node_modules` and complain about the missing modules that it just destroyed.

To work around this autophagy mechanism try to remove npm from node_modules after installing dependencies.