### PR TITLE
Stop downloading node

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,13 +109,12 @@ task installKibi(dependsOn: [downloadKibi, extractKibi, npmInstallKibi]) {}
 node {
     // Version of node to use.
     version = nodeVersion
-
     // Base URL for fetching node distributions (change if you have a mirror).
     distBaseUrl = 'https://nodejs.org/dist'
 
     // If true, it will download node using above parameters.
     // If false, it will try to use globally installed node.
-    download = true
+    download = false
 
     // Set the work directory for unpacking node
     workDir = file("${buildDir}/nodejs")


### PR DESCRIPTION
Enhanced tilemap builds are [failing](https://build.siren.io/view/Snapshots/job/snapshot/job/plugins/job/enhanced-tilemap/2094/console) - this might not fix it but worth adding in any case. 

This uses the node version installed into the jenkins slave rather than pulling a new node instance each time. Have seen similar issues previously which were stabilised by this. 

https://build.siren.io/view/Snapshots/job/snapshot/job/plugins/job/enhanced-tilemap/2094/console