### PR TITLE
Draw all layers once on move-end or zoom-end

### DIFF
--- a/public/lib/dragAndDroplayercontrol/DndLayerControl.js
+++ b/public/lib/dragAndDroplayercontrol/DndLayerControl.js
@@ -285,6 +285,8 @@ function destroy() {
       layer.destroy();
     }
   });
+  _leafletMap.off('moveend');
+  _leafletMap.off('zoomend');
   _allLayers = undefined;
 }
 

--- a/public/lib/dragAndDroplayercontrol/DndLayerControl.js
+++ b/public/lib/dragAndDroplayercontrol/DndLayerControl.js
@@ -316,15 +316,12 @@ L.Control.DndLayerControl = L.Control.extend({
   destroy,
 
   onAdd: function (map) {
+    const debouncedHandler = debounce(() => {
+      _redrawMriLayers();
+    }, 500);
     _leafletMap = map;
-
-    _leafletMap.on('moveend', debounce(() => {
-      _redrawMriLayers();
-    }, 150, false));
-
-    _leafletMap.on('zoomend', debounce(() => {
-      _redrawMriLayers();
-    }, 150, false));
+    _leafletMap.on('moveend', debouncedHandler);
+    _leafletMap.on('zoomend', debouncedHandler);
 
     this._initLayout();
     return this._container;


### PR DESCRIPTION
### Description
Single debounce handler for `zoom-end` and `move-end` events. 
_Color change shows re-render (Not checked in)_

### Issue
![mri_behaviour_err](https://user-images.githubusercontent.com/7285903/79729976-16841580-82e8-11ea-9f0a-826201308538.gif)

### Fix
![mri_behaviour_fix_500](https://user-images.githubusercontent.com/7285903/79729989-1d128d00-82e8-11ea-9740-545ca3ab40e1.gif)
