### PR TITLE
Specifying larger bucket size for tree aggs query

### DIFF
--- a/public/lib/dragAndDroplayercontrol/layerContolTree.js
+++ b/public/lib/dragAndDroplayercontrol/layerContolTree.js
@@ -133,7 +133,8 @@ export class AddMapLayersModal extends React.Component {
           2: {
             terms: {
               field: 'spatial_path',
-              order: { _key: 'asc' }
+              order: { _key: 'asc' },
+              size: 9999
             }
           }
         },


### PR DESCRIPTION
![layerControlTreeWithBiggerNumbersWorking](https://user-images.githubusercontent.com/36197976/79760031-5d3d3400-8317-11ea-82ac-bbb904314deb.gif)
