### PR TITLE
Tooltip now appearing if there is an ellipsis for long layer names

### DIFF
--- a/public/lib/dragAndDroplayercontrol/uiLayerControlDnd.js
+++ b/public/lib/dragAndDroplayercontrol/uiLayerControlDnd.js
@@ -153,12 +153,10 @@ export class LayerControlDnd extends React.Component {
                           }}></div>
                         }
 
-                        {/* <span className="panel-label"> */}
-                        <EllipsisWithTooltip className="label" placement="left"
+                        <EllipsisWithTooltip placement="left"
                         >
                           {layer.label}
                         </EllipsisWithTooltip>
-                        {/* </span> */}
 
                         {layer.tooManyDocsInfo && <div
                           dangerouslySetInnerHTML={{

--- a/public/vis.less
+++ b/public/vis.less
@@ -466,3 +466,8 @@
 .euiTreeView {
   padding-inline-start: 0;
 }
+
+// for long layer name ellipsis in layer control
+.fade.show.tooltip.bs-tooltip-left {
+  opacity: 0.8;
+}


### PR DESCRIPTION
![longellipsisNamesworkingtooltip](https://user-images.githubusercontent.com/36197976/80367512-24efa580-8883-11ea-9aa0-64241acef8b8.gif)
