### PR TITLE
Adding threshold to Add And Enable button

### DIFF
--- a/public/lib/dragAndDroplayercontrol/layerContolTree.js
+++ b/public/lib/dragAndDroplayercontrol/layerContolTree.js
@@ -314,11 +314,11 @@ export class AddMapLayersModal extends React.Component {
         <div style={{ height: '10px' }}></div>
         <div>
           {this.state.selectedLayerCount > ADD_LAYERS_ENABLED_THRESHOLD &&
-            <EuiCallOut title={`Adding many layers at once?`} color="warning" iconType="help">
-              <p>When there are more than {`${ADD_LAYERS_ENABLED_THRESHOLD}`} layers selected,
-            you may only use the Add option.</p>
-              <p>This will add layers to the map without them being visible.
-            You can can turn them on individually by checking them from the map layer control.</p>
+            <EuiCallOut title={`Adding multiple layers?`} color="warning" iconType="help">
+              <p>When more than {`${ADD_LAYERS_ENABLED_THRESHOLD}`} layers are selected,
+              only the Add option is available.</p>
+              <p>To make the layers visible after they are added, select the individual
+                checkbox for each layer in <b>Layer Control</b>.</p>
             </EuiCallOut>
           }
         </div>
@@ -353,7 +353,7 @@ export class AddMapLayersModal extends React.Component {
             }}
             isDisabled={this.state.selectedLayerCount > ADD_LAYERS_ENABLED_THRESHOLD}
           >
-            Add and Enable
+            Add and Display
           </EuiButton>
         </EuiFlexItem>
 

--- a/public/lib/dragAndDroplayercontrol/layerContolTree.js
+++ b/public/lib/dragAndDroplayercontrol/layerContolTree.js
@@ -23,7 +23,8 @@ export class AddMapLayersModal extends React.Component {
     super(props);
     this.state = {
       items: [],
-      value: ''
+      value: '',
+      selectedLayerCount: 0
     };
   }
 
@@ -246,6 +247,7 @@ export class AddMapLayersModal extends React.Component {
     countChecked(items);
 
     return {
+      checkedCount,
       someItemsChecked: checkedCount !== totalCount && checkedCount >= 1,
       noItemsChecked: checkedCount === 0
     };
@@ -275,7 +277,8 @@ export class AddMapLayersModal extends React.Component {
       }
       this._recursivelyToggleIndeterminate(list);
       return {
-        items: list
+        items: list,
+        selectedLayerCount: this._checkIfAnyItemInGroupAndSubGroupChecked(list).checkedCount
       };
     });
 
@@ -309,7 +312,6 @@ export class AddMapLayersModal extends React.Component {
       </div>
     );
 
-
     const footer = (
       <EuiFlexGroup gutterSize="s" alignItems="center">
         <EuiFlexItem grow={false}>
@@ -327,6 +329,7 @@ export class AddMapLayersModal extends React.Component {
         <EuiFlexItem grow={false}>
           <EuiButton
             data-test-subj={'addLayersDisabledBtn'}
+            fill
             size="s"
             iconType="plusInCircle"
             onClick={() => {
@@ -339,9 +342,21 @@ export class AddMapLayersModal extends React.Component {
         </EuiFlexItem>
 
         <EuiFlexItem grow={false}>
-          <EuiButton
+          {this.state.selectedLayerCount > 35 && <EuiButton
             data-test-subj={'addLayersEnableBtn'}
-            fill
+            size="s"
+            iconType="plusInCircle"
+            onClick={() => {
+              this._addLayersEnabled();
+              this.onClose();
+            }}
+            isDisabled
+          >
+            Add and Enable
+          </EuiButton>}
+
+          {this.state.selectedLayerCount <= 35 && <EuiButton
+            data-test-subj={'addLayersEnableBtn'}
             size="s"
             iconType="plusInCircle"
             onClick={() => {
@@ -350,7 +365,7 @@ export class AddMapLayersModal extends React.Component {
             }}
           >
             Add and Enable
-          </EuiButton>
+          </EuiButton>}
         </EuiFlexItem>
       </EuiFlexGroup>
     );

--- a/public/lib/dragAndDroplayercontrol/layerContolTree.js
+++ b/public/lib/dragAndDroplayercontrol/layerContolTree.js
@@ -342,7 +342,7 @@ export class AddMapLayersModal extends React.Component {
         </EuiFlexItem>
 
         <EuiFlexItem grow={false}>
-          {this.state.selectedLayerCount > 35 && <EuiButton
+          <EuiButton
             data-test-subj={'addLayersEnableBtn'}
             size="s"
             iconType="plusInCircle"
@@ -350,22 +350,10 @@ export class AddMapLayersModal extends React.Component {
               this._addLayersEnabled();
               this.onClose();
             }}
-            isDisabled
+            isDisabled={this.state.selectedLayerCount >= 35}
           >
             Add and Enable
-          </EuiButton>}
-
-          {this.state.selectedLayerCount <= 35 && <EuiButton
-            data-test-subj={'addLayersEnableBtn'}
-            size="s"
-            iconType="plusInCircle"
-            onClick={() => {
-              this._addLayersEnabled();
-              this.onClose();
-            }}
-          >
-            Add and Enable
-          </EuiButton>}
+          </EuiButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     );

--- a/public/lib/dragAndDroplayercontrol/layerContolTree.js
+++ b/public/lib/dragAndDroplayercontrol/layerContolTree.js
@@ -343,21 +343,6 @@ export class AddMapLayersModal extends React.Component {
 
         <EuiFlexItem grow={false}>
           <EuiButton
-            data-test-subj={'addLayersDisabledBtn'}
-            fill
-            size="s"
-            iconType="plusInCircle"
-            onClick={() => {
-              this._addLayersNotEnabled();
-              this.onClose();
-            }}
-          >
-            Add
-          </EuiButton>
-        </EuiFlexItem>
-
-        <EuiFlexItem grow={false}>
-          <EuiButton
             data-test-subj={'addLayersEnableBtn'}
             size="s"
             iconType="plusInCircle"
@@ -368,6 +353,21 @@ export class AddMapLayersModal extends React.Component {
             isDisabled={this.state.selectedLayerCount > this.state.ADD_LAYERS_ENABLED_THRESHOLD}
           >
             Add and Enable
+          </EuiButton>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiButton
+            data-test-subj={'addLayersDisabledBtn'}
+            fill
+            size="s"
+            iconType="plusInCircle"
+            onClick={() => {
+              this._addLayersNotEnabled();
+              this.onClose();
+            }}
+          >
+            Add
           </EuiButton>
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/public/lib/dragAndDroplayercontrol/layerContolTree.js
+++ b/public/lib/dragAndDroplayercontrol/layerContolTree.js
@@ -19,14 +19,14 @@ function capitalizeFirstLetter(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
+const ADD_LAYERS_ENABLED_THRESHOLD = 35;
 export class AddMapLayersModal extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       items: [],
       value: '',
-      selectedLayerCount: 0,
-      ADD_LAYERS_ENABLED_THRESHOLD: 35
+      selectedLayerCount: 0
     };
   }
 
@@ -313,9 +313,9 @@ export class AddMapLayersModal extends React.Component {
         </div>
         <div style={{ height: '10px' }}></div>
         <div>
-          {this.state.selectedLayerCount > this.state.ADD_LAYERS_ENABLED_THRESHOLD &&
+          {this.state.selectedLayerCount > ADD_LAYERS_ENABLED_THRESHOLD &&
             <EuiCallOut title={`Adding many layers at once?`} color="warning" iconType="help">
-              <p>When there are more than {`${this.state.ADD_LAYERS_ENABLED_THRESHOLD}`} layers selected,
+              <p>When there are more than {`${ADD_LAYERS_ENABLED_THRESHOLD}`} layers selected,
             you may only use the Add option.</p>
               <p>This will add layers to the map without them being visible.
             You can can turn them on individually by checking them from the map layer control.</p>
@@ -351,7 +351,7 @@ export class AddMapLayersModal extends React.Component {
               this._addLayersEnabled();
               this.onClose();
             }}
-            isDisabled={this.state.selectedLayerCount > this.state.ADD_LAYERS_ENABLED_THRESHOLD}
+            isDisabled={this.state.selectedLayerCount > ADD_LAYERS_ENABLED_THRESHOLD}
           >
             Add and Enable
           </EuiButton>

--- a/public/lib/dragAndDroplayercontrol/layerContolTree.js
+++ b/public/lib/dragAndDroplayercontrol/layerContolTree.js
@@ -26,7 +26,7 @@ export class AddMapLayersModal extends React.Component {
       items: [],
       value: '',
       selectedLayerCount: 0,
-      ADD_LAYERS_ENABLED_THRESHOLD: 4
+      ADD_LAYERS_ENABLED_THRESHOLD: 35
     };
   }
 

--- a/public/lib/dragAndDroplayercontrol/layerContolTree.js
+++ b/public/lib/dragAndDroplayercontrol/layerContolTree.js
@@ -9,7 +9,8 @@ import {
   EuiFlexItem,
   EuiFlexGroup,
   EuiButtonEmpty,
-  EuiIcon
+  EuiIcon,
+  EuiCallOut
 } from '@elastic/eui';
 import { EuiTreeViewCheckbox } from './euiTreeViewCheckbox';
 import { modalWithForm } from './../../vislib/modals/genericModal';
@@ -24,7 +25,8 @@ export class AddMapLayersModal extends React.Component {
     this.state = {
       items: [],
       value: '',
-      selectedLayerCount: 0
+      selectedLayerCount: 0,
+      ADD_LAYERS_ENABLED_THRESHOLD: 35
     };
   }
 
@@ -309,8 +311,21 @@ export class AddMapLayersModal extends React.Component {
             }}
           />
         </div>
+        <div>
+          {this.state.selectedLayerCount > this.state.ADD_LAYERS_ENABLED_THRESHOLD &&
+            <EuiCallOut title={`Adding many layers at once?`} color="warning" iconType="help">
+              <p>When there are more than {`${this.state.ADD_LAYERS_ENABLED_THRESHOLD}`} layers selected,
+            you may only use the Add option.</p>
+              <p>This will add layers to the map without them being visible.
+            You can can turn them on individually by checking them from the map layer control.</p>
+            </EuiCallOut>
+          }
+        </div>
       </div>
     );
+
+
+
 
     const footer = (
       <EuiFlexGroup gutterSize="s" alignItems="center">
@@ -350,7 +365,7 @@ export class AddMapLayersModal extends React.Component {
               this._addLayersEnabled();
               this.onClose();
             }}
-            isDisabled={this.state.selectedLayerCount >= 35}
+            isDisabled={this.state.selectedLayerCount > this.state.ADD_LAYERS_ENABLED_THRESHOLD}
           >
             Add and Enable
           </EuiButton>

--- a/public/lib/dragAndDroplayercontrol/layerContolTree.js
+++ b/public/lib/dragAndDroplayercontrol/layerContolTree.js
@@ -26,7 +26,7 @@ export class AddMapLayersModal extends React.Component {
       items: [],
       value: '',
       selectedLayerCount: 0,
-      ADD_LAYERS_ENABLED_THRESHOLD: 35
+      ADD_LAYERS_ENABLED_THRESHOLD: 4
     };
   }
 
@@ -311,6 +311,7 @@ export class AddMapLayersModal extends React.Component {
             }}
           />
         </div>
+        <div style={{ height: '10px' }}></div>
         <div>
           {this.state.selectedLayerCount > this.state.ADD_LAYERS_ENABLED_THRESHOLD &&
             <EuiCallOut title={`Adding many layers at once?`} color="warning" iconType="help">


### PR DESCRIPTION
So the changes are:
- The add layers button is now filled while the add and enable button is empty (it used to be the other way around)
- If there are more than 35 layer checkboxes ticked (i.e. the performance threshold and to avoid browser crash), the Add and Enable button will be greyed out. I have tested this with a threshold of 4 as per GIF

![GreyedOutAddLayersButton](https://user-images.githubusercontent.com/36197976/80374815-3048ce00-888f-11ea-8707-9c335c4ce976.gif)
