### PR TITLE
Expand by default causing ui tree to be continuously open

### DIFF
--- a/public/lib/dragAndDroplayercontrol/euiTreeViewCheckbox.js
+++ b/public/lib/dragAndDroplayercontrol/euiTreeViewCheckbox.js
@@ -36,6 +36,7 @@ class EuiTreeViewCheckbox extends EuiTreeView {
 
   render() {
     const {
+      toggleoffexpandbydefault,
       children,
       className,
       items,
@@ -141,7 +142,10 @@ class EuiTreeViewCheckbox extends EuiTreeView {
                               onKeyDown={(event) =>
                                 this.onKeyDown(event, node)
                               }
-                              onClick={() => this.handleNodeClick(node)}
+                              onClick={() => {
+                                this.handleNodeClick(node);
+                                this.props.toggleoffexpandbydefault();
+                              }}
                               className={nodeButtonClasses}
                               style={{ paddingLeft: '10px' }}
                             >
@@ -179,6 +183,7 @@ class EuiTreeViewCheckbox extends EuiTreeView {
                             }>
                             {node.children && this.isNodeOpen(node) ? (
                               <EuiTreeViewCheckbox
+                                toggleoffexpandbydefault={this.props.toggleoffexpandbydefault}
                                 onChange={this.props.onChange}
                                 items={node.children}
                                 display={display}

--- a/public/lib/dragAndDroplayercontrol/layerContolTree.js
+++ b/public/lib/dragAndDroplayercontrol/layerContolTree.js
@@ -26,7 +26,8 @@ export class AddMapLayersModal extends React.Component {
     this.state = {
       items: [],
       value: '',
-      selectedLayerCount: 0
+      selectedLayerCount: 0,
+      expandByDefault: true
     };
   }
 
@@ -278,8 +279,12 @@ export class AddMapLayersModal extends React.Component {
         selectedLayerCount: this._checkIfAnyItemInGroupAndSubGroupChecked(list).checkedCount
       };
     });
-
   }
+
+  toggleoffexpandbydefault = () => {
+    this.setState({ expandByDefault: false });
+  }
+
   render() {
     const title = 'Add Layers';
     const form = (
@@ -297,9 +302,10 @@ export class AddMapLayersModal extends React.Component {
         <div style={{ overflowY: 'scroll', border: '1px solid lightgrey' }}>
           <EuiTreeViewCheckbox
             onChange={(e) => this._toggleItems(e)}
+            toggleoffexpandbydefault={() => this.toggleoffexpandbydefault()}
             items={this.state.items}
             display={'default'}
-            expandByDefault={true}
+            expandByDefault={this.state.expandByDefault}
             showExpansionArrows={false}
             style={{
               height: '300px'


### PR DESCRIPTION
I turned off the expand by default option the first time a group is whatever the opposite of expanded is

To be merged after - https://github.com/sirensolutions/enhanced_tilemap/pull/210

![TurningOffExpandByDefaultOnFirstGroupMinimisation](https://user-images.githubusercontent.com/36197976/80404759-8fbbd380-88b9-11ea-81ae-210e89111939.gif)
