### PR TITLE
heatmap layer types sit on top of tile layers, but behind polygon layer types

### DIFF
--- a/public/lib/dragAndDroplayercontrol/DndLayerControl.js
+++ b/public/lib/dragAndDroplayercontrol/DndLayerControl.js
@@ -34,12 +34,7 @@ let mainSearchDetails;
 const _debouncedRedrawOverlays = debounce(_redrawOverlays, 400);
 
 function _isHeatmapLayer(layer) {
-  if (layer.options && layer.options.blur) {
-    return true;
-  } else {
-    return false;
-  }
-
+  return layer.options && layer.options.blur;
 }
 
 function _setZIndexOfAnyLayerType(layer, zIndex, leafletMap) {

--- a/public/lib/dragAndDroplayercontrol/DndLayerControl.js
+++ b/public/lib/dragAndDroplayercontrol/DndLayerControl.js
@@ -33,6 +33,15 @@ let mainSearchDetails;
 
 const _debouncedRedrawOverlays = debounce(_redrawOverlays, 400);
 
+function _isHeatmapLayer(layer) {
+  if (layer.options && layer.options.blur) {
+    return true;
+  } else {
+    return false;
+  }
+
+}
+
 function _setZIndexOfAnyLayerType(layer, zIndex, leafletMap) {
   if (layer.type === 'poi_point' ||
     layer.type === 'vector_point' ||
@@ -47,7 +56,9 @@ function _setZIndexOfAnyLayerType(layer, zIndex, leafletMap) {
       marker.setZIndexOffset(zIndex - pos.y + 300);// 198); //for now, we don't need to layer marker types with overlay types
     });
   } else {
-    layer.setZIndex(zIndex);
+    if (!_isHeatmapLayer(layer)) {
+      layer.setZIndex(zIndex);
+    }
   }
 }
 
@@ -66,6 +77,8 @@ function _orderLayersByType() {
       markerTemp.push(layer);
     } else if (pointTypes.includes(layer.type)) {
       markerLayersTemp.push(layer);
+    } else if (_isHeatmapLayer(layer)) {
+      tileLayersTemp.unshift(layer);
     } else {
       overlaysTemp.push(layer);
     }


### PR DESCRIPTION
@niknbr, heatmap is another case where zIndex is hard to set. This PR will mean that the heatmap layer will be drawn behind polygon layer types, but in front of tile layer types. Also tested with WMS layer.

![heatmapdefaultdrawnbehindpolygonlayertypes](https://user-images.githubusercontent.com/36197976/80581551-3660bb00-8a05-11ea-8372-b0af2df4d122.gif)
