### PR TITLE
Better Error handling for stored layers config

### DIFF
--- a/public/visController.js
+++ b/public/visController.js
@@ -117,10 +117,13 @@ define(function (require) {
     function getSirenMeta() { return $scope.vis._siren; }
     function getStoredLayerConfig() {
       try {
-        return _.orderBy(JSON.parse($scope.vis.params.storedLayerConfig), ['spatial_path'], ['asc']);
+        if ($scope.vis.params.storedLayerConfig === '') {
+          notify.warning(`Detected an empty Stored Layer Config with Stored Layers present`);
+        } else {
+          return _.orderBy(JSON.parse($scope.vis.params.storedLayerConfig), ['spatial_path'], ['asc']);
+        }
       } catch (error) {
-        notify.error(`An issue with your Stored Layer Configuration has been detected:
-        ${error}`);
+        notify.error(`An issue with your Stored Layer Configuration has been detected: ${error}`);
       }
     }
 

--- a/public/vislib/vector_layer_types/EsLayer.js
+++ b/public/vislib/vector_layer_types/EsLayer.js
@@ -21,7 +21,9 @@ export default class EsLayer {
     }
 
     if (type === 'es_ref') {
-      self.assignLayerLevelConfigurations(options.storedLayerConfig, options);
+      if (options.storedLayerConfig) {
+        self.assignLayerLevelConfigurations(options.storedLayerConfig, options);
+      }
     }
 
     if (geo) {


### PR DESCRIPTION
If stored layers is empty AND you add a stored layer: 
![image](https://user-images.githubusercontent.com/36197976/80714471-e3fac980-8aec-11ea-8eda-be816c35aa3a.png)

If there is a syntax error in stored layers, a toast will be displayed containing the console message, e.g. 
![image](https://user-images.githubusercontent.com/36197976/80714653-1dcbd000-8aed-11ea-8b84-4d88d84b07f6.png)

