### PR TITLE
use a default Stored Layer config if there is none defined

### DIFF
--- a/public/config/config.js
+++ b/public/config/config.js
@@ -1,0 +1,14 @@
+
+const defaultStoredLayerConfig = () => {
+  return JSON.stringify([{
+    icon: 'fas fa-arrow-alt-circle-down',
+    color: '#7CBFFA',
+    popupFields: [],
+    minZoom: 0,
+    maxZoom: 18
+  }]);
+};
+
+export {
+  defaultStoredLayerConfig
+};

--- a/public/config/config.js
+++ b/public/config/config.js
@@ -1,12 +1,10 @@
 
-const defaultStoredLayerConfig = () => {
-  return JSON.stringify([{
-    icon: 'fas fa-arrow-alt-circle-down',
-    color: '#7CBFFA',
-    popupFields: [],
-    minZoom: 0,
-    maxZoom: 18
-  }]);
+const defaultStoredLayerConfig = {
+  icon: 'fas fa-arrow-alt-circle-down',
+  color: '#7CBFFA',
+  popupFields: [],
+  minZoom: 0,
+  maxZoom: 18
 };
 
 export {

--- a/public/directives/storedLayerConfig.js
+++ b/public/directives/storedLayerConfig.js
@@ -1,3 +1,5 @@
+import  { defaultStoredLayerConfig } from '../config/config';
+
 const module = require('ui/modules').get('kibana');
 
 define(function (require) {
@@ -10,16 +12,8 @@ define(function (require) {
       },
       template: require('./storedLayerConfig.html'),
       link: function (scope) {
-        if (!scope.config) {
-          scope.config = JSON.stringify([
-            {
-              icon: 'fas fa-arrow-alt-circle-down',
-              color: '#7CBFFA',
-              popupFields: [],
-              minZoom: 0,
-              maxZoom: 18
-            }
-          ]);
+        if (!scope.config || scope.config.length === 0) {
+          scope.config = defaultStoredLayerConfig();
         }
         //converting object to JSON
         scope.$watch('config', function (newConfig, oldConfig) {

--- a/public/directives/storedLayerConfig.js
+++ b/public/directives/storedLayerConfig.js
@@ -10,7 +10,17 @@ define(function (require) {
       },
       template: require('./storedLayerConfig.html'),
       link: function (scope) {
-
+        if (!scope.config) {
+          scope.config = JSON.stringify([
+            {
+              icon: 'fas fa-arrow-alt-circle-down',
+              color: '#7CBFFA',
+              popupFields: [],
+              minZoom: 0,
+              maxZoom: 18
+            }
+          ]);
+        }
         //converting object to JSON
         scope.$watch('config', function (newConfig, oldConfig) {
           if (newConfig !== oldConfig) {

--- a/public/directives/storedLayerConfig.js
+++ b/public/directives/storedLayerConfig.js
@@ -13,7 +13,7 @@ define(function (require) {
       template: require('./storedLayerConfig.html'),
       link: function (scope) {
         if (!scope.config || scope.config.length === 0) {
-          scope.config = defaultStoredLayerConfig();
+          scope.config = JSON.stringify([defaultStoredLayerConfig]);
         }
         //converting object to JSON
         scope.$watch('config', function (newConfig, oldConfig) {

--- a/public/directives/storedLayerConfig.js
+++ b/public/directives/storedLayerConfig.js
@@ -13,7 +13,7 @@ define(function (require) {
       template: require('./storedLayerConfig.html'),
       link: function (scope) {
         if (!scope.config || scope.config.length === 0) {
-          scope.config = JSON.stringify([defaultStoredLayerConfig]);
+          scope.config = JSON.stringify([defaultStoredLayerConfig], null, ' ');
         }
         //converting object to JSON
         scope.$watch('config', function (newConfig, oldConfig) {


### PR DESCRIPTION
fix for - https://sirensolutions.atlassian.net/browse/INVE-11395

To be merged on or after Wednesday 13th May

When visualization loads (new, previous version or previous vis on current version) and the config field is empty string, the default will be added to the text area as below. If there is already one present, it will not update: 
![image](https://user-images.githubusercontent.com/36197976/81551882-76fff300-937a-11ea-8d66-c36cd54ea223.png)
