### PR TITLE
Heatmap popups now disappearing when disabling layer

### DIFF
--- a/public/visController.js
+++ b/public/visController.js
@@ -113,6 +113,9 @@ define(function (require) {
       };
     }
 
+    function isHeatMap() {
+      return $scope.vis.params.mapType === 'Heatmap' && map._markers;
+    }
     function getIndexPatternId() { return $scope.vis.indexPattern.id; }
     function getSirenMeta() { return $scope.vis._siren; }
     function getStoredLayerConfig() {
@@ -337,9 +340,6 @@ define(function (require) {
         if (_shouldAutoFitMapBoundsToData(true)) _doFitMapBoundsToData();
         $scope.flags.isVisibleSource = 'visParams';
         //remove mouse related heatmap events when moving to a different geohash type
-        if (oldParams && oldParams.mapType === 'Heatmap') {
-          map.unfixMapTypeTooltips();
-        }
 
         map._layerControl.setStoredLayerConfigs(getStoredLayerConfig());
         map.removeAllLayersFromMapandControl();
@@ -369,6 +369,10 @@ define(function (require) {
           _doFitMapBoundsToData();
         }
         draw();
+      }
+
+      if (isHeatMap()) {
+        map.unfixMapTypeTooltips();
       }
 
       //POI overlays - no need to clear all layers for this watcher
@@ -686,6 +690,9 @@ define(function (require) {
     map.leafletMap.on('showlayer', function (e) {
       map.saturateWMSTiles();
       if (map._markers && e.id === 'Aggregation') {
+        if (isHeatMap()) {
+          map.fixMapTypeTooltips();
+        }
         map._markers.show();
       }
       $scope.vis.getUiState().set(e.id, true);
@@ -693,6 +700,9 @@ define(function (require) {
 
     map.leafletMap.on('hidelayer', function (e) {
       if (map._markers && e.id === 'Aggregation') {
+        if (isHeatMap()) {
+          map.unfixMapTypeTooltips();
+        }
         map._markers.hide();
       }
       $scope.vis.getUiState().set(e.id, false);

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -395,6 +395,10 @@ define(function (require) {
       this._markers.unfixTooltips();
     };
 
+    TileMapMap.prototype.fixMapTypeTooltips = function () {
+      this._markers.fixTooltips();
+    };
+
     TileMapMap.prototype._setMarkerType = function (markerType) {
       this._markerType = markerTypes[markerType] ? markerType : defaultMarkerType;
     };

--- a/public/vislib/marker_types/heatmap.js
+++ b/public/vislib/marker_types/heatmap.js
@@ -39,7 +39,7 @@ define(function (require) {
       const points = this._dataToHeatArray(max);
 
       this._markerGroup = L.heatLayer(points, options);
-      this._fixTooltips();
+      this.fixTooltips();
       this._addToMap();
     };
 
@@ -50,7 +50,7 @@ define(function (require) {
       this.leafletMap.off('mouseup');
     };
 
-    HeatmapMarker.prototype._fixTooltips = function () {
+    HeatmapMarker.prototype.fixTooltips = function () {
       const self = this;
       const debouncedMouseMoveLocation = _.debounce(mouseMoveLocation.bind(this), 15, {
         'leading': true,


### PR DESCRIPTION
fix for - https://sirensolutions.atlassian.net/browse/INVE-11319

To be merged on or after Wednesday 13th May

Heatmap popups work when changing vis params, panning and zooming the maps AND when toggling visibility on and off

![HeatMapPopupsTogglingOffWhenLayercontrolIsToggledOff](https://user-images.githubusercontent.com/36197976/81560134-b3d2e680-9388-11ea-8785-feae2492b4bc.gif)
