### PR TITLE
Removal of linting errors and warnings

### DIFF
--- a/public/lib/dragAndDroplayercontrol/DndLayerControl.js
+++ b/public/lib/dragAndDroplayercontrol/DndLayerControl.js
@@ -429,7 +429,7 @@ function getExtendedMapControl() {
         layer.destroy();
       }
     });
-    _leafletMap.off('moveend');
+    _leafletMap.off('click').off('wheel');
     _allLayers = undefined;
   }
 

--- a/public/lib/dragAndDroplayercontrol/euiTreeViewCheckbox.js
+++ b/public/lib/dragAndDroplayercontrol/euiTreeViewCheckbox.js
@@ -36,11 +36,14 @@ class EuiTreeViewCheckbox extends EuiTreeView {
 
   render() {
     const {
+      // eslint-disable-next-line no-unused-vars
       toggleoffexpandbydefault,
+      // eslint-disable-next-line no-unused-vars
       children,
       className,
       items,
       display = 'default',
+      // eslint-disable-next-line no-unused-vars
       expandByDefault,
       showExpansionArrows,
       ...rest
@@ -94,11 +97,11 @@ class EuiTreeViewCheckbox extends EuiTreeView {
                         'aria-labelledby': `${buttonId} ${
                           rest['aria-labelledby']}`,
                       };
-                    const nodeClasses = classNames(
-                      'euiTreeView__node',
-                      display ? displayToClassNameMap[display] : null,
-                      { 'euiTreeView__node--expanded': this.isNodeOpen(node) }
-                    );
+                    // const nodeClasses = classNames(
+                    //   'euiTreeView__node',
+                    //   display ? displayToClassNameMap[display] : null,
+                    //   { 'euiTreeView__node--expanded': this.isNodeOpen(node) }
+                    // );
                     const nodeButtonClasses = classNames(
                       'euiTreeView__nodeInner',
                       showExpansionArrows && node.children

--- a/public/lib/dragAndDroplayercontrol/euiTreeViewCheckbox.js
+++ b/public/lib/dragAndDroplayercontrol/euiTreeViewCheckbox.js
@@ -97,11 +97,6 @@ class EuiTreeViewCheckbox extends EuiTreeView {
                         'aria-labelledby': `${buttonId} ${
                           rest['aria-labelledby']}`,
                       };
-                    // const nodeClasses = classNames(
-                    //   'euiTreeView__node',
-                    //   display ? displayToClassNameMap[display] : null,
-                    //   { 'euiTreeView__node--expanded': this.isNodeOpen(node) }
-                    // );
                     const nodeButtonClasses = classNames(
                       'euiTreeView__nodeInner',
                       showExpansionArrows && node.children

--- a/public/lib/jquery.minicolors/jquery.minicolors.js
+++ b/public/lib/jquery.minicolors/jquery.minicolors.js
@@ -1,4 +1,4 @@
-/* eslint-disable siren/memoryleaks */
+/* eslint-disable siren/memory-leak */
 /*
  * jQuery MiniColors: A tiny color picker built on jQuery
  *
@@ -754,6 +754,7 @@
     const settings = input.data('minicolors-settings');
     const lastChange = input.data('minicolors-lastChange');
     let obj;
+    // eslint-disable-next-line no-unused-vars
     let sel;
     let i;
 

--- a/public/visController.js
+++ b/public/visController.js
@@ -1,5 +1,4 @@
 /* eslint-disable siren/memory-leak */
-/* eslint-disable siren/memoryleaks */
 
 import _ from 'lodash';
 import uuid from 'uuid';

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -1,5 +1,5 @@
 /* eslint-disable siren/memory-leak */
-/* eslint-disable siren/memoryleaks */
+
 import { markerIcon } from 'plugins/enhanced_tilemap/vislib/markerIcon';
 
 define(function (require) {


### PR DESCRIPTION
Fix for - https://sirensolutions.atlassian.net/browse/INVE-11313

To be merged on or after Wednesday 13th May

Some Notes -
* Events created in vis controller and dndlayercotrol.js are turned off in _map.js
* According to https://stackoverflow.com/questions/7549188/are-event-listeners-in-jquery-removed-automatically-when-you-remove-the-element, jquery events are removed automatically, so removed warnings from the jquery.minicolors.js file
* Added remove lint warning lines to euiTreeView.js warnings. The variables are actually/may acutally be used

![image](https://user-images.githubusercontent.com/36197976/81574655-02d74680-939e-11ea-83f6-d8beac4fefc1.png)
