### PR TITLE
Set width instead of fit-content and removed height on button

### DIFF
--- a/public/vis.less
+++ b/public/vis.less
@@ -143,7 +143,6 @@
     >div.leaflet-control-layers-add-layer {
       visibility: collapse;
       .euiButton {
-        height: 20px;
         transition: none;
         display: block;
         margin: 0 auto;
@@ -185,8 +184,7 @@
   // when layer control is toggled on
   .leaflet-control-layers.leaflet-control.leaflet-control-layers-expanded {
     height: auto;
-    width: fit-content;
-    max-width: 300px;
+    width: 300px;
     padding: 0 0 10px 0;
 
     >form.leaflet-control-layers-header {


### PR DESCRIPTION
[INVE-11461] Fixes width issue in Firefox (fit width not supported, also a fixed width is generally better) and removed height from button (it changes standard EUI styles and is inconsistent)
![image](https://user-images.githubusercontent.com/1306680/82130821-c5702000-97c6-11ea-9967-3a610936182c.png)


[INVE-11461]: https://sirensolutions.atlassian.net/browse/INVE-11461