### PR TITLE
Drag icon color

### DIFF
--- a/public/vis.less
+++ b/public/vis.less
@@ -212,7 +212,7 @@
           }
         span.panel-drag-handler {
           span.far.fa-grip-lines {
-            color: #ffffff;
+            color: @kibanaGray4;
             &:hover {
               color: @kibanaGray2;
           }

--- a/public/vis.less
+++ b/public/vis.less
@@ -137,8 +137,8 @@
 
   // when layer control is toggled off
   .leaflet-control-layers.leaflet-control {
-    height: 55px;
-    width: 55px;
+    height: 38px;
+    width: 38px;
    
     >div.leaflet-control-layers-add-layer {
       visibility: collapse;
@@ -150,8 +150,7 @@
     }
 
     a.leaflet-control-layers-toggle {
-      margin-left: 4.5px;
-      margin-top: 5px;
+      margin-left: -0.5px;
     }
 
     >form.leaflet-control-layers-header {
@@ -168,7 +167,6 @@
       display: flex;
       flex-direction: column;
       .leaflet-control-layers-toggle{
-        padding: 20px;
       }
       .leaflet-control-layers-list {
         padding: 10px;

--- a/public/vis.less
+++ b/public/vis.less
@@ -150,7 +150,7 @@
     }
 
     a.leaflet-control-layers-toggle {
-      margin-left: -0.5px;
+      margin-left: -1px;
     }
 
     >form.leaflet-control-layers-header {
@@ -247,7 +247,7 @@
     padding            : 5px;
     padding-left       : 33px;
     background-position: 5px;
-    padding-top        : 10px;
+    padding-top        : 22px;
     margin             : 2px;
   }
 


### PR DESCRIPTION
### Description
Update default color of drag icons (=) so that they are visible (not sure if they are white by design. Ignore this PR if so.)

<img width="654" alt="image" src="https://user-images.githubusercontent.com/7285903/82179805-1b33ed80-98d7-11ea-9cff-a3f0ac6a953c.png">
