### PR TITLE
Drag handles changed from vertical to horizontal

### DIFF
--- a/public/lib/dragAndDroplayercontrol/uiLayerControlDnd.js
+++ b/public/lib/dragAndDroplayercontrol/uiLayerControlDnd.js
@@ -134,7 +134,7 @@ export class LayerControlDnd extends React.Component {
                         )}
                       >
                         <span {...provided.dragHandleProps} className="panel-drag-handler">
-                          <span className={'fas fa-grip-horizontal'}
+                          <span className={'fas fa-grip-vertical'}
                           />
                         </span>
 

--- a/public/vis.less
+++ b/public/vis.less
@@ -218,7 +218,7 @@
               }
           }
         span.panel-drag-handler {
-          span.fas.fa-grip-horizontal {
+          span.fas.fa-grip-vertical {
             color: @kibanaGray4;
             &:hover {
               color: @kibanaGray2;


### PR DESCRIPTION

Fix for - https://sirensolutions.atlassian.net/browse/INVE-11518

@jccq requested change from vertical to horizontal grip handle similar to cards on gb: 

was: 
![image](https://user-images.githubusercontent.com/36197976/82373514-96032280-9a15-11ea-8709-a60762bd15e5.png)

now:
![image](https://user-images.githubusercontent.com/36197976/82373385-694f0b00-9a15-11ea-980a-916b8eeb67d4.png)

