### PR TITLE
Fire showLayer only when adding layer or toggling layers

### DIFF
--- a/public/lib/dragAndDroplayercontrol/DndLayerControl.js
+++ b/public/lib/dragAndDroplayercontrol/DndLayerControl.js
@@ -130,11 +130,6 @@ function getExtendedMapControl() {
         _leafletMap.addLayer(layer);
         zIndex++;
       }
-      _leafletMap.fire('showlayer', {
-        layerType: layer.type,
-        id: layer.id,
-        enabled: layer.enabled
-      });
     }
   }
 
@@ -196,6 +191,11 @@ function getExtendedMapControl() {
     _allLayers[index].enabled = enabled;
     if (enabled) {
       _redrawOverlays();
+      _leafletMap.fire('showlayer', {
+        layerType: layer.type,
+        id: layer.id,
+        enabled: enabled
+      });
     } else {
       _clearLayerFromMapById(layer.id);
       _leafletMap.fire('hidelayer', {
@@ -350,7 +350,15 @@ function getExtendedMapControl() {
     const esRefLayerList = [];
     _updateCurrentZoom();
     for (const item of list) {
-      esRefLayerList.push(await getEsRefLayer(item.path, item.enabled));
+      const layer = await getEsRefLayer(item.path, item.enabled);
+      esRefLayerList.push(layer);
+      if (layer.enabled) {
+        _leafletMap.fire('showlayer', {
+          layerType: layer.type,
+          id: layer.id,
+          enabled: layer.enabled
+        });
+      }
     }
     addOverlays(esRefLayerList);
     addEsRefLayers(list);

--- a/public/lib/dragAndDroplayercontrol/uiLayerControlDnd.js
+++ b/public/lib/dragAndDroplayercontrol/uiLayerControlDnd.js
@@ -101,8 +101,9 @@ export class LayerControlDnd extends React.Component {
       this.setState(prevState => {
         const newListOrder = [...prevState.dndCurrentListOrder];
         newListOrder[index].enabled = target.checked;
-        this.props.dndLayerVisibilityChange(target.checked, layer, index);
         return { dndCurrentListOrder: newListOrder };
+      }, () => {
+        this.props.dndLayerVisibilityChange(target.checked, layer, index);
       });
     }
   }


### PR DESCRIPTION
### Description 
Fire leaflet `showLayer` event only when adding (with enabled) layers from layer control tree or toggling layers on the drag-and-drop layer control.

### Before
![slow_checkbox_issue_2](https://user-images.githubusercontent.com/7285903/82420644-ed39df00-9a77-11ea-975f-025b54185c57.gif)

### After
![slow_checkbox_fix_2](https://user-images.githubusercontent.com/7285903/82420655-f034cf80-9a77-11ea-9be9-3c1e6e00ce51.gif)

### Update
![MapLayerControl_v2](https://user-images.githubusercontent.com/7285903/82419564-82d46f00-9a76-11ea-9b14-e9aaf317fc87.png)


### Issue
Fixes[INVE-11485]


[INVE-11485]: https://sirensolutions.atlassian.net/browse/INVE-11485