### PR TITLE
Handling case where there are no stored layers present in ES

### DIFF
--- a/public/lib/dragAndDroplayercontrol/layerContolTree.js
+++ b/public/lib/dragAndDroplayercontrol/layerContolTree.js
@@ -133,7 +133,12 @@ export class AddMapLayersModal extends React.Component {
 
   getItems = async () => {
     const resp = await this.props.getPathList();
-    const aggs = resp.aggregations[2].buckets;
+    let aggs = [];
+
+    if (resp) {
+      aggs = resp.aggregations[2].buckets;
+    }
+
     this.setState({
       items: this._makeUiTreeStructure(aggs)
     });


### PR DESCRIPTION
Fix for - https://sirensolutions.atlassian.net/browse/INVE-11544

I've tested on an instance where there are stored layers present (normal kibi-distribution)and on an instance where there are no stored layers present (ssh to contact.demo.siren.io). There were no errors in logs on visualization load or when the add layers button is clicked. Both of those cases are where the error logs were happening. 

The fix was to return from get paths only if there is a valid response. Then populating the layer tree modal or loading stored layers on visualization processes are skipped if the response is undefined. 

Example of response where there are stored layers (there is an aggregations object in response):
![image](https://user-images.githubusercontent.com/36197976/82544332-dfa25900-9b4c-11ea-83e8-9ff52248a871.png)


Example of response where there are NOT stored layers (there is not an aggregations object in response):
![image](https://user-images.githubusercontent.com/36197976/82544259-c7cad500-9b4c-11ea-8389-dc8778575c9f.png)
