### PR TITLE
Fix for collar scale being ignored

### DIFF
--- a/public/callbacks.js
+++ b/public/callbacks.js
@@ -35,8 +35,7 @@ define(function (require) {
       fetchSearchSource: function (event) {
         //Fetch new data if map bounds are outsize of collar
         const bounds = utils.geoBoundingBoxBounds(event.mapBounds, 1);
-        const autoPrecision = _.get(event, 'chart.geohashGridAgg.params.autoPrecision');
-        if (_.has(event, 'collar.top_left') && !utils.contains(event.collar, bounds) || autoPrecision) {
+        if (_.has(event, 'collar.top_left') && !utils.contains(event.collar, bounds)) {
           event.searchSource.fetch();
         }
       },

--- a/public/callbacks.js
+++ b/public/callbacks.js
@@ -35,8 +35,14 @@ define(function (require) {
       fetchSearchSource: function (event) {
         //Fetch new data if map bounds are outsize of collar
         const bounds = utils.geoBoundingBoxBounds(event.mapBounds, 1);
-        if (_.has(event, 'collar.top_left') && !utils.contains(event.collar, bounds)) {
-          event.searchSource.fetch();
+        const autoPrecision = _.get(event, 'chart.geohashGridAgg.params.autoPrecision');
+        const previousZoom = _.get(event, 'chart.geoJson.properties.zoom');
+        if (_.has(event, 'collar.top_left')) {
+          if (autoPrecision && (event.currentZoom !== previousZoom || !utils.contains(event.collar, bounds))) {
+            event.searchSource.fetch();
+          } else if (!autoPrecision && !utils.contains(event.collar, bounds))  {
+            event.searchSource.fetch();
+          }
         }
       },
       poiFilter: function (event) {

--- a/public/visController.js
+++ b/public/visController.js
@@ -737,15 +737,17 @@ define(function (require) {
       if (!map.leafletMap) return;
       if (map._hasSameLocation()) return;
 
+      const currentZoom = map.leafletMap.getZoom();
       // update internal center and zoom references
       map._mapCenter = map.leafletMap.getCenter();
       $scope.vis.getUiState().set('mapCenter', [
         _.round(map._mapCenter.lat, 5),
         _.round(map._mapCenter.lng, 5)
       ]);
-      $scope.vis.getUiState().set('mapZoom', map.leafletMap.getZoom());
+      $scope.vis.getUiState().set('mapZoom', currentZoom);
 
       map._callbacks.fetchSearchSource({
+        currentZoom,
         searchSource: $scope.searchSource,
         collar: map._collar,
         chart: map._chartData,


### PR DESCRIPTION
Fix for - https://sirensolutions.atlassian.net/browse/INVE-11564

Previously, each time the map was zoomed or panned, auto precision being true meant that the fetch was executed. I've now created an if/else to handle cases with auto precision on and off. 

When panning: We need to fetch new data only if the new map canvas extent happens to be outside of the collar. If the new map canvas extent is within the collar scale bounds, the data from the previously executed fetch is sufficient. GIF below shows fetch only being executed when outside of the 1.5 collar scale (i.e. from USA to Europe): 

When changing zoom: If there is a change in zoom, we need to execute fetch as the current data may need to be updated to reflect the change in (zoom level based) precision. 

![fixForCollarScaleNotBeingApplied](https://user-images.githubusercontent.com/36197976/82575466-6c1a3f00-9b80-11ea-95f0-4e83830b7dac.gif)
