### PR TITLE
Marker clustering styling (part 2)

### DIFF
--- a/public/vislib/icons/markerClusteringIcon.js
+++ b/public/vislib/icons/markerClusteringIcon.js
@@ -2,18 +2,38 @@ const L = require('leaflet');
 
 export const markerClusteringIcon = function (thisClusterCount, maxAggDocCount, faIcon, color) {
 
-  const mediumSizeThreshold = maxAggDocCount * 0.20;
-  const largeSizeThreshold = maxAggDocCount * 0.85;
+  faIcon = `${faIcon} fa-2x`; // current default is medium size
 
-  let backgroundColor = '#80a2ff';
-  if (thisClusterCount >= mediumSizeThreshold) backgroundColor = '#fff780';
-  if (thisClusterCount >= largeSizeThreshold) backgroundColor = '#ff8880';
+  function colorLuminance(lum) {
+    const hex = '444444'; // constant color, pass hex to this function and uncomment below if layer specific colors are desired
+    // validate hex string
+    // hex = String(hex).replace(/[^0-9a-f]/gi, '');
+    // if (hex.length < 6) {
+    //   hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
+    // }
 
-  faIcon = `${faIcon} fa-2x`; // current default is medium
+    lum = lum || 0;
+
+    // convert to decimal and change luminosity
+    let rgb = '#';
+    let c;
+    let i;
+    for (i = 0; i < 3; i++) {
+      c = parseInt(hex.substr(i * 2, 2), 16);
+      c = Math.round(Math.min(Math.max(0, c + (c * lum)), 255)).toString(16);
+      rgb += ('00' + c).substr(c.length);
+    }
+
+    return rgb;
+  }
+
+  const luminosityFactor = 1 - (thisClusterCount / maxAggDocCount); // making it lighter
+  const backgroundColor = colorLuminance(luminosityFactor);
+  // console.log(thisClusterCount, 'luminosityFactor: ', luminosityFactor, 'backgroundColor: ' , backgroundColor);
 
   function getBaseStyle() {
     return 'width: fit-content; ' +
-      'height: fit-content;';
+      'height: 21px;';
   }
 
   function getOuterStyle() {
@@ -24,11 +44,8 @@ export const markerClusteringIcon = function (thisClusterCount, maxAggDocCount, 
   function getCountStyle() {
     return getBaseStyle() +
       'border-radius: 10px; ' +
-      'border: solid;' +
-      'border-width: 0.5px; ' +
-      `border-color: ${color}; ` +
-      'opacity: 1; ' +
       `background-color: ${backgroundColor}; ` +
+      'color: #FFFFFF;' +
       'padding: 2px;';
   }
 

--- a/public/vislib/icons/markerClusteringIcon.js
+++ b/public/vislib/icons/markerClusteringIcon.js
@@ -5,13 +5,7 @@ export const markerClusteringIcon = function (thisClusterCount, maxAggDocCount, 
   faIcon = `${faIcon} fa-2x`; // current default is medium size
 
   function colorLuminance(lum) {
-    const hex = '444444'; // constant color, pass hex to this function and uncomment below if layer specific colors are desired
-    // validate hex string
-    // hex = String(hex).replace(/[^0-9a-f]/gi, '');
-    // if (hex.length < 6) {
-    //   hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
-    // }
-
+    const hex = '444444'; // constant color
     lum = lum || 0;
 
     // convert to decimal and change luminosity
@@ -29,7 +23,6 @@ export const markerClusteringIcon = function (thisClusterCount, maxAggDocCount, 
 
   const luminosityFactor = 1 - (thisClusterCount / maxAggDocCount); // making it lighter
   const backgroundColor = colorLuminance(luminosityFactor);
-  // console.log(thisClusterCount, 'luminosityFactor: ', luminosityFactor, 'backgroundColor: ' , backgroundColor);
 
   function getBaseStyle() {
     return 'width: fit-content; ' +


### PR DESCRIPTION
Fix for - https://sirensolutions.atlassian.net/browse/INVE-11640
Fix for - https://sirensolutions.atlassian.net/browse/INVE-11646

To be merged after - https://github.com/sirensolutions/enhanced_tilemap/pull/256

Halo removed and colour ramp added as described in - https://sirensolutions.atlassian.net/browse/INVE-11640

There are clustering layers present on the map. Note that the 268 is dark as it has the highest count for the companies poi layer. While the trees layer has lighter colors for higher numbers (because 700k is the highest number for this layer)

![image](https://user-images.githubusercontent.com/36197976/84769922-8fdd7300-afce-11ea-956b-02a6054447a9.png)
