### PR TITLE
[INVE-11883] Map layers icon fix

### DIFF
--- a/public/vislib/vector_layer_types/EsLayer.js
+++ b/public/vislib/vector_layer_types/EsLayer.js
@@ -134,12 +134,11 @@ export default class EsLayer {
           layer.warning = `There are undisplayed POIs for this overlay due
         to having reached the limit currently set to ${options.warning.limit}`;
         }
-        if (geo.type === 'line') {
+        if (geo.type === 'linestring' || geo.type === 'multilinestring') {
           layer.icon = `<i class="far fa-horizontal-rule" style="color:${layerControlColor};"></i>`;
         } else {
           layer.icon = `<i class="far fa-draw-square" style="color:${layerControlColor};"></i>`;
         }
-        layer.icon = `<i class="far fa-stop" style="color:${layerControlColor};"></i>`;
         layer.type = type + '_shape';
         layer.destroy = () => layer.options.destroy();
       } else {
@@ -171,7 +170,7 @@ export default class EsLayer {
 
       if (geo.type === 'point' || geo.type === 'geo_point') {
         layer.icon = `<i class="${options.icon}" style="color:${options.color};"></i>`;
-      } else if (geo.type.includes('line')) {
+      } else if (geo.type === 'line') {
         layer.icon = `<i class="far fa-horizontal-rule" style="color:${options.color};"></i>`;
       } else {
         layer.icon = `<i class="far fa-draw-square" style="color:${options.color};"></i>`;


### PR DESCRIPTION
This is a fix for map layer icons. 

1. Forgot to delete a line.
2. Fixed `if` statements and made them use direct comparison `===` rather than `.include()` 

With data
![image](https://user-images.githubusercontent.com/28691446/84962607-26a94d00-b0ff-11ea-8429-08fe71f2fe5e.png)

Without data
![image](https://user-images.githubusercontent.com/28691446/84962645-42145800-b0ff-11ea-8d33-742cae82ccea.png)
