### PR TITLE
XYZ layers and desaturate working with new layer control

### DIFF
--- a/public/directives/wmsOverlay.html
+++ b/public/directives/wmsOverlay.html
@@ -87,7 +87,7 @@
 
       Visible On Load
       
-      <kbn-info info="When true, this layer will draw when the visualization is loaded.">
+      <kbn-info info="When true, WMS layers will draw when the visualization is loaded.">
       </kbn-info>
     </label>
   </div>

--- a/public/lib/dragAndDroplayercontrol/DndLayerControl.js
+++ b/public/lib/dragAndDroplayercontrol/DndLayerControl.js
@@ -132,6 +132,11 @@ function getExtendedMapControl() {
         zIndex++;
       }
     }
+    _leafletMap.eachLayer(layer => {
+      if (layer.type === 'base' || layer.type === 'wms') {
+        mainSearchDetails.saturateWMSTile(layer);
+      }
+    });
   }
 
   function _addOrReplaceLayer(layer) {

--- a/public/visController.js
+++ b/public/visController.js
@@ -639,7 +639,8 @@ define(function (require) {
                 nonTiled: _.get(layerParams, 'nonTiled', false)
               };
 
-              if (layerParams.url.includes('{x}') && layerParams.url.includes('{y}') && layerParams.url.includes('{z}')) { // checking for XYZ tile server
+              const urlLowerCase = layerParams.url.toLowerCase();
+              if (urlLowerCase.includes('{x}') && urlLowerCase.includes('{y}') && urlLowerCase.includes('{z}')) { // checking for XYZ tile server
                 layerParams.url = layerParams.url;
               } else if (layerParams.url.substr(layerParams.url.length - 5).toLowerCase() !== '/wms?') {
                 layerParams.url = layerParams.url + '/wms?';

--- a/public/visController.js
+++ b/public/visController.js
@@ -304,6 +304,10 @@ define(function (require) {
       return { geo_shape: geoShapeBox };
     }
 
+    function saturateWMSTile(layer) {
+      map.saturateTile($scope.vis.params.isDesaturated, layer);
+    }
+
     function _drawPoiLayers(poiLayerArray, queryFilterChange) {
       if (!poiLayerArray) return;
 
@@ -430,8 +434,6 @@ define(function (require) {
         await drawLayers(true);
         //re-draw vector overlays
         drawWfsOverlays();
-
-        map.saturateTile(visParams.isDesaturated, map._tileLayer);
       }
     });
 
@@ -629,20 +631,7 @@ define(function (require) {
               let enabled;
               if ($scope.flags.isVisibleSource === 'visParams') {
                 enabled = layerParams.isVisible;
-                // } else if (prevState.enabled ||
-                //   $scope.flags.isVisibleSource === 'layerControlCheckbox') {
-                //   enabled = prevState.enabled;
-              } else {
-                enabled = layerParams.isVisible;
               }
-
-              const presentInUiState = uiState.get(name);
-              if (presentInUiState) {
-                enabled = true;
-              } else if (presentInUiState === false) {
-                enabled = false;
-              }
-
               $scope.flags.visibleSource = '';
 
               const options = {
@@ -650,12 +639,15 @@ define(function (require) {
                 nonTiled: _.get(layerParams, 'nonTiled', false)
               };
 
-              if (layerParams.url.substr(layerParams.url.length - 5).toLowerCase() !== '/wms?') layerParams.url = layerParams.url + '/wms?';
+              if (layerParams.url.includes('{x}') && layerParams.url.includes('{y}') && layerParams.url.includes('{z}')) { // checking for XYZ tile server
+                layerParams.url = layerParams.url;
+              } else if (layerParams.url.substr(layerParams.url.length - 5).toLowerCase() !== '/wms?') {
+                layerParams.url = layerParams.url + '/wms?';
+              }
               return map.addWmsOverlay(layerParams.url, name, wmsOptions, options, layerParams.id);
             });
         });
       });
-
     }
 
     function _updateCurrentMapEnvironment() {
@@ -693,6 +685,7 @@ define(function (require) {
         geoFilter,
         storedLayerConfig: getStoredLayerConfig(),
         uiState,
+        saturateWMSTile,
       };
 
       map = new TileMapMap(container, {
@@ -849,8 +842,6 @@ define(function (require) {
 
     // saving checkbox status to dashboard uiState
     map.leafletMap.on('showlayer', async function (e) {
-      map.saturateWMSTiles();
-
       if (e.layerType === 'es_ref_shape' || e.layerType === 'es_ref_point') {
         let refLayerState = 'sne'; //saved but NOT enabled
         if (e.enabled) {
@@ -903,7 +894,6 @@ define(function (require) {
 
     // saving checkbox status to dashboard uiState
     map.leafletMap.on('overlayadd', function (e) {
-      map.saturateWMSTiles();
       if (map._markers && e.id === 'Aggregation') {
         map._markers.show();
       }

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -307,25 +307,15 @@ define(function (require) {
       overlay.label = name;
       overlay.icon = `<i class="fas fa-map" style="color:#000000;"></i>`;
       overlay.visible = true;
-      // if (options.enabled) this.leafletMap.addLayer(overlay);
 
       const presentInUiState = this.uiState.get(id);
-      if (presentInUiState) {
+      if (presentInUiState || options.enabled) {
         overlay.enabled = true;
       } else if (presentInUiState === false) {
         overlay.enabled = false;
       }
 
       this._layerControl.addOverlays([overlay], options);
-      this.saturateTile(this._attr.isDesaturated, overlay);
-    };
-
-    TileMapMap.prototype.saturateWMSTiles = function () {
-      this.allLayers.forEach(layer => {
-        if (layer.type === 'wms') {
-          this.saturateTile(this._attr.isDesaturated, layer);
-        }
-      });
     };
 
     TileMapMap.prototype.mapBounds = function () {
@@ -477,6 +467,7 @@ define(function (require) {
       this._tileLayer.setZIndex(-10);
       this._tileLayer.type = 'base';
       this._tileLayer.addTo(this.leafletMap);
+      this.saturateTile(this._attr.isDesaturated, this._tileLayer);
 
       // see note in _addDrawControl function
       // this._layerControl.addOverlays([this._drawnItems]);


### PR DESCRIPTION
@jefersonzanim, @manu4387 , you asked me about this one in the last couple of weeks. 

XYZ tile servers should now be working again. @jefersonzanim would like to confirm that if the WMS url contains `{x}` AND `{y}` AND `{z}`, the url can be considered an XYZ tile server? This seems to be the case for all XYZ available on - https://leaflet-extras.github.io/leaflet-providers/preview/

The logic to convert the url into a WMS request is then skipped (which is the fix). This is a regression, and happened when making the WMS requests compatible with ArcGIS server a few months ago.  

Example XYZ url: 
https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}

![XYZTileServersWorking](https://user-images.githubusercontent.com/36197976/85038561-a1657d00-b17e-11ea-9572-8a63b1227272.gif)
