### PR TITLE
Map center and zoom level from sessionStorage if available

### DIFF
--- a/public/lib/dragAndDroplayercontrol/DndLayerControl.js
+++ b/public/lib/dragAndDroplayercontrol/DndLayerControl.js
@@ -22,7 +22,6 @@ function getExtendedMapControl() {
   let $element;
   let mainSearchDetails;
   let geometryTypeOfSpatialPaths;
-  let uiState;
 
 
   const _debouncedRedrawOverlays = debounce(_redrawOverlays, 400);
@@ -663,7 +662,7 @@ function getExtendedMapControl() {
       const savedStoredLayers = [];
       _updateCurrentMapEnvironment();
       aggs.forEach(agg => {
-        const currentUiState = uiState.get(agg.key);
+        const currentUiState = mainSearchDetails.sirenSessionState.get(agg.key);
         const storedLayerTemplate = {
           id: agg.key,
           path: agg.key,
@@ -730,7 +729,6 @@ function getExtendedMapControl() {
       _allLayers = allLayers;
       esClient = es;
       mainSearchDetails = mSD;
-      uiState = mSD.uiState;
       this._lastZIndex = 0;
       $element = $el;
 

--- a/public/lib/dragAndDroplayercontrol/DndLayerControl.js
+++ b/public/lib/dragAndDroplayercontrol/DndLayerControl.js
@@ -507,13 +507,11 @@ function getExtendedMapControl() {
         layer.visible = true;
       }
       esRefLayerList.push(layer);
-      if (layer.enabled) {
-        _leafletMap.fire('showlayer', {
-          layerType: layer.type,
-          id: layer.id,
-          enabled: layer.enabled
-        });
-      }
+      _leafletMap.fire('showlayer', {
+        layerType: layer.type,
+        id: layer.id,
+        enabled: layer.enabled
+      });
     }
     addOverlays(esRefLayerList);
     addEsRefLayers(esRefLayerList);

--- a/public/utils.js
+++ b/public/utils.js
@@ -154,32 +154,6 @@ define(function (require) {
         }
       };
     },
-    getMapStateFromVis: function (vis) {
-      const mapState = {};
-      //Visualizations created in 5.x will have map state in uiState
-      if (vis.hasUiState()) {
-        const uiStateCenter = vis.uiStateVal('mapCenter');
-        const uiStateZoom = vis.uiStateVal('mapZoom');
-        if (uiStateCenter && uiStateZoom) {
-          mapState.center = uiStateCenter;
-          mapState.zoom = uiStateZoom;
-        }
-      }
-      //Visualizations created in 4.x will have map state in segment aggregation
-      if (!_.has(mapState, 'center') && !_.has(mapState, 'zoom')) {
-        const agg = this.getAggConfig(vis.aggs, 'segment');
-        if (agg) {
-          mapState.center = _.get(agg, 'params.mapCenter');
-          mapState.zoom = _.get(agg, 'params.mapZoom');
-        }
-      }
-      //Provide defaults if no state found
-      if (!_.has(mapState, 'center') && !_.has(mapState, 'zoom')) {
-        mapState.center = [15, 5];
-        mapState.zoom = 2;
-      }
-      return mapState;
-    },
     /**
      * Avoid map auto panning. Use the offset option to
      * anchor popups so content fits inside map bounds.

--- a/public/visController.js
+++ b/public/visController.js
@@ -670,6 +670,7 @@ define(function (require) {
       _currentMapEnvironment.currentMapBoundsWithCollar = getMapBoundsWithCollar();
       _currentMapEnvironment.currentZoom = map.leafletMap.getZoom();
       _currentMapEnvironment.currentClusteringPrecision = utils.getMarkerClusteringPrecision(_currentMapEnvironment.currentZoom);
+      _currentMapEnvironment.mapCenter = map.leafletMap.getCenter();
 
       if ($scope.vis.aggs[1]) {
         const precisionType = $scope.vis.aggs[1].params.aggPrecisionType.toLowerCase();
@@ -921,15 +922,14 @@ define(function (require) {
 
     map.leafletMap.on('moveend', _.debounce(async function setZoomCenter() {
       if (!map.leafletMap) return;
-      if (map._hasSameLocation()) return;
-
       _updateCurrentMapEnvironment();
+      // check if map zoom/center has change and update uiState if so
+      if (map._hasSameLocation(_currentMapEnvironment.mapCenter, _currentMapEnvironment.currentZoom)) return;
 
-      // update internal center and zoom references
-      map._mapCenter = map.leafletMap.getCenter();
+      // update uiState center and zoom references
       uiState.set('mapCenter', [
-        _.round(map._mapCenter.lat, 5),
-        _.round(map._mapCenter.lng, 5)
+        _.round(_currentMapEnvironment.mapCenter.lat, 5),
+        _.round(_currentMapEnvironment.mapCenter.lng, 5)
       ]);
       uiState.set('mapZoom', _currentMapEnvironment.currentZoom);
 

--- a/public/visController.js
+++ b/public/visController.js
@@ -685,7 +685,6 @@ define(function (require) {
 
 
     function appendMap() {
-      const initialMapState = utils.getMapStateFromVis($scope.vis);
       const params = $scope.vis.params;
       const container = $element[0].querySelector('.tilemap');
       container.id = `etm-vis-${$scope.vis.panelIndex}`;
@@ -708,8 +707,6 @@ define(function (require) {
         mainSearchDetails,
         $element,
         es,
-        center: initialMapState.center,
-        zoom: initialMapState.zoom,
         callbacks: callbacks,
         mapType: params.mapType,
         attr: params,

--- a/public/visController.js
+++ b/public/visController.js
@@ -69,6 +69,7 @@ define(function (require) {
 
     async function initialize() {
       backwardsCompatible.updateParams($scope.vis.params);
+      // Note - true, false, se (saved and enabled on map), sne (saved but not enabled on map) and undefined (new to uistate) are all possible states
       sirenSessionState = new SirenSessionState();
       sirenSessionState.register(uiState, sirenSession, $route.current.params.id, $scope.vis.id);
       createDragAndDropPoiLayers();

--- a/public/visController.js
+++ b/public/visController.js
@@ -325,8 +325,8 @@ define(function (require) {
           layerParams.enabled = true;
         }
 
-        const warning = _.get(map._layerControl.getLayerById(layerParams.id), 'warning');
         const layerOnMap = map._layerControl.getLayerById(layerParams.id);
+        const warning = _.get(layerOnMap, 'warning');
         if (!layerOnMap || // add the layer to the map so it will appear on layer control
           (queryFilterChange && layerParams.enabled) ||
           utils.drawLayerCheck(layerParams,
@@ -882,10 +882,10 @@ define(function (require) {
 
       if (e.layerType === 'poi_shape' || e.layerType === 'poi_point') {
         const layerParams = getPoiLayerParamsById(e.id);
-        const warning = _.get(map._layerControl.getLayerById(e.id), 'warning');
         layerParams.enabled = e.enabled;
         layerParams.type = e.layerType;
         const layerOnMap = map._layerControl.getLayerById(layerParams.id);
+        const warning = _.get(layerOnMap, 'warning');
         if (!layerOnMap ||
           utils.drawLayerCheck(layerParams,
             _currentMapEnvironment.currentMapBounds,

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -52,11 +52,12 @@ define(function (require) {
       // keep a reference to all of the optional params
       this.mainSearchDetails = params.mainSearchDetails;
       this.uiState = params.uiState;
+      this.sirenSessionState = params.sirenSessionState;
       this.aggLayerParams = {};
       this._callbacks = _.get(params, 'callbacks');
       this._setMarkerType(params.mapType);
-      this._mapCenter = L.latLng(this.uiState.get('mapCenter')) || L.latLng(defaultMapCenter);
-      this._mapZoom = this.uiState.get('mapZoom') || defaultMapZoom;
+      this._mapCenter = L.latLng(this.sirenSessionState.get('mapCenter')) || L.latLng(defaultMapCenter);
+      this._mapZoom = this.sirenSessionState.get('mapZoom') || defaultMapZoom;
       this._setAttr(params.attr);
       this._isEditable = params.editable || false;
 
@@ -209,7 +210,7 @@ define(function (require) {
 
     TileMapMap.prototype.addFeatureLayer = function (layer) {
       const id = layer.id;
-      if (this.uiState.get(id) || this.uiState.get(id) === undefined) layer.enabled = true;
+      if (this.sirenSessionState.get(id)) layer.enabled = true;
       this._layerControl.addOverlays([layer]);
 
       //Add tool to l.draw.toolbar so users can filter by vector layers
@@ -242,6 +243,7 @@ define(function (require) {
 
       this._markers = this._createMarkers({
         uiState: this.uiState,
+        sirenSessionState: this.sirenSessionState,
         tooltipFormatter: tooltipFormatter,
         valueFormatter: valueFormatter,
         prevState: prevState,
@@ -275,7 +277,7 @@ define(function (require) {
       this._filters.type = 'filter';
       this._filters.icon = `<i class="far fa-filter" style="color:${style.color};"></i>`;
       // the uiState takes precedence
-      this._filters.enabled = this.uiState.get(this._filters.id);
+      this._filters.enabled = this.sirenSessionState.get(this._filters.id);
       this._filters.visible = true;
       this._layerControl.addOverlays([this._filters]);
     };

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -209,8 +209,7 @@ define(function (require) {
     };
 
     TileMapMap.prototype.addFeatureLayer = function (layer) {
-      const id = layer.id;
-      if (this.sirenSessionState.get(id)) layer.enabled = true;
+      if (this.sirenSessionState.get(layer.id)) layer.enabled = true;
       this._layerControl.addOverlays([layer]);
 
       //Add tool to l.draw.toolbar so users can filter by vector layers

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -55,9 +55,8 @@ define(function (require) {
       this.aggLayerParams;
       this._callbacks = _.get(params, 'callbacks');
       this._setMarkerType(params.mapType);
-      const centerArray = _.get(params, 'center') || defaultMapCenter;
-      this._mapCenter = L.latLng(centerArray[0], centerArray[1]);
-      this._mapZoom = _.get(params, 'zoom') || defaultMapZoom;
+      this._mapCenter = L.latLng(this.uiState.get('mapCenter')) || L.latLng(defaultMapCenter);
+      this._mapZoom = this.uiState.get('mapZoom') || defaultMapZoom;
       this._setAttr(params.attr);
       this._isEditable = params.editable || false;
 
@@ -424,16 +423,19 @@ define(function (require) {
       });
     };
 
-    TileMapMap.prototype._hasSameLocation = function () {
+    TileMapMap.prototype._hasSameLocation = function (currentCenter, currentZoom) {
       const oldLat = this._mapCenter.lat.toFixed(5);
       const oldLon = this._mapCenter.lng.toFixed(5);
-      const newLat = this.leafletMap.getCenter().lat.toFixed(5);
-      const newLon = this.leafletMap.getCenter().lng.toFixed(5);
+      const newLat = currentCenter.lat.toFixed(5);
+      const newLon = currentCenter.lng.toFixed(5);
       let isSame = false;
       if (oldLat === newLat
         && oldLon === newLon
         && this.leafletMap.getZoom() === this._mapZoom) {
         isSame = true;
+      } else {
+        this._mapZoom = currentZoom;
+        this._mapCenter = L.latLng(currentCenter);
       }
       return isSame;
     };

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -52,7 +52,7 @@ define(function (require) {
       // keep a reference to all of the optional params
       this.mainSearchDetails = params.mainSearchDetails;
       this.uiState = params.uiState;
-      this.aggLayerParams;
+      this.aggLayerParams = {};
       this._callbacks = _.get(params, 'callbacks');
       this._setMarkerType(params.mapType);
       this._mapCenter = L.latLng(this.uiState.get('mapCenter')) || L.latLng(defaultMapCenter);

--- a/public/vislib/marker_types/base_marker.js
+++ b/public/vislib/marker_types/base_marker.js
@@ -16,6 +16,7 @@ define(function (require) {
      */
     function BaseMarker(leafletMap, geoJson, layerControl, params) {
       this.uiState = params.uiState;
+      this.sirenSessionState = params.sirenSessionState;
       this.leafletMap = leafletMap;
       this.geoJson = geoJson;
       this.layerControl = layerControl;
@@ -266,7 +267,7 @@ define(function (require) {
     BaseMarker.prototype._addToMap = function () {
       this._markerGroup.enabled = true;
       // the uiState takes precedence
-      if (this.uiState.get('Aggregation') === false) {
+      if (this.sirenSessionState.get('Aggregation') === false) {
         this._markerGroup.enabled = false;
       }
 

--- a/public/vislib/session_state.js
+++ b/public/vislib/session_state.js
@@ -15,13 +15,20 @@ export default class SirenSessionState {
     if (sirenSessionData.map && sirenSessionData.map[sirenSessionId]) {
       this._sessionState = sirenSessionData.map[sirenSessionId];
     } else {
-      //create new state for this dashboard/vis combination
+      // create new state for this dashboard/vis combination
       if (!sirenSessionData.map) {
         sirenSessionData.map = {};
       }
       if (onDashboardPage()) {
-        this._sessionState = sirenSessionData.map[sirenSessionId] = cloneDeep(uiState._defaultState[uiState._path]);
+        if (typeof uiState._parent._changedState[uiState._path] === 'object') {
+          // use the dashboard specific state if there is one
+          this._sessionState = sirenSessionData.map[sirenSessionId] = cloneDeep(uiState._parent._changedState[uiState._path]);
+        } else {
+          // otherwise use the state that is saved with the visualization
+          this._sessionState = sirenSessionData.map[sirenSessionId] = cloneDeep(uiState._defaultState[uiState._path]);
+        }
       } else {
+        // if in vis edit mode
         this._sessionState = sirenSessionData.map[sirenSessionId] = cloneDeep(uiState._mergedState);
       }
     }

--- a/public/vislib/session_state.js
+++ b/public/vislib/session_state.js
@@ -1,0 +1,37 @@
+import { cloneDeep } from 'lodash';
+import { onDashboardPage } from 'ui/kibi/utils/on_page';
+
+export default class SirenSessionState {
+  // Note - true, false, se (saved and enabled on map), sne (saved but not enabled on map) and undefined (new to uistate) are all possible states
+  // A temporary fix is to use siren session to store uiState. This is pending an overall uistate improvement.
+  // See comment on - https://sirensolutions.atlassian.net/browse/INVE-11900
+  constructor() {
+    this._sessionState;
+  }
+  register = (uiState, sirenSession, rootId, visId) => {
+    this._sessionState;
+    const sirenSessionId = rootId + visId;
+    const sirenSessionData = sirenSession.getData();
+    if (sirenSessionData.map && sirenSessionData.map[sirenSessionId]) {
+      this._sessionState = sirenSessionData.map[sirenSessionId];
+    } else {
+      //create new state for this dashboard/vis combination
+      if (!sirenSessionData.map) {
+        sirenSessionData.map = {};
+      }
+      if (onDashboardPage()) {
+        this._sessionState = sirenSessionData.map[sirenSessionId] = cloneDeep(uiState._defaultState[uiState._path]);
+      } else {
+        this._sessionState = sirenSessionData.map[sirenSessionId] = cloneDeep(uiState._mergedState);
+      }
+    }
+  }
+
+  get = (key) => {
+    return this._sessionState[key];
+  };
+  set = (key, value) => {
+    this._sessionState[key] = value;
+  };
+}
+

--- a/public/vislib/session_state.js
+++ b/public/vislib/session_state.js
@@ -2,7 +2,6 @@ import { cloneDeep } from 'lodash';
 import { onDashboardPage } from 'ui/kibi/utils/on_page';
 
 export default class SirenSessionState {
-  // Note - true, false, se (saved and enabled on map), sne (saved but not enabled on map) and undefined (new to uistate) are all possible states
   // A temporary fix is to use siren session to store uiState. This is pending an overall uistate improvement.
   // See comment on - https://sirensolutions.atlassian.net/browse/INVE-11900
   constructor() {


### PR DESCRIPTION
The idea is to swap out session storage when uiState is refactored. What happens in this PR :

- Loading vis the sirenSession object is checked for presence of uiState, this is used if it is present. The id for each vis is `rootId` + `visId`
- If vis not present in siren session, then the regular uiState is used, if there is no uiState, the default state is used
- The uiState functionality is maintained throughout the visualization, i.e. the uiState is updated alongside the sessionState
Manual Testing (carried out by me):

**Note - you clear session state by refreshing browser**
**State refers to the visibility of layers visible/not visible stored layers, enabled/not enabled all layers, map zoom and the centre point of the map**
- [x] Same ETM vis on two separate visualizations (the state of dashboard A should be the same when returning as it was when navigating away, same with dashboard B)
- [x] Navigating to visualization mode (via the pencil icon in the top right of the visualization) and back to dashboard mode should retain the same state.
- [x] Loading dashboard on a new tab should reload the saved dashboard state of both A and B, i.e. the session state is lost and the saved dashboard state should be reloaded when loading dashboard for the first time
- [x] Adding visualization to new dashboard, the vis state should be used initially. If the dashboard is saved, the dashboard state is persisted and used when opening dashboard on new browser tab
- [x] Before merge, move comment from siren_session.js to where it is implemented in visController.js