### PR TITLE
Revisiting XYZ tile servers

### DIFF
--- a/public/directives/wmsOverlay.js
+++ b/public/directives/wmsOverlay.js
@@ -49,14 +49,14 @@ define(function (require) {
         }
 
         //this is for the initial rendering of the map
-        if (scope.layer.url && !utils.isXYZurl(scope.layer.url)) {
+        if (scope.layer.url && !utils.isXyzUrl(scope.layer.url)) {
           wmsRequest(scope.layer.url);
         }
 
         //Watchers for url and getCapabilitiesSwitch equals to 0 or 1
         //this is for subsequent rendering based on changes to the wms url
         scope.$watch('layer.url', function (newUrl, oldUrl) {
-          if (newUrl !== oldUrl && !utils.isXYZurl(newUrl)) {
+          if (newUrl !== oldUrl && !utils.isXyzUrl(newUrl)) {
             wmsRequest(newUrl);
           }
         });

--- a/public/directives/wmsOverlay.js
+++ b/public/directives/wmsOverlay.js
@@ -1,4 +1,5 @@
 const module = require('ui/modules').get('kibana');
+const utils = require('plugins/enhanced_tilemap/utils');
 import { parseString } from 'xml2js';
 import uuid from 'uuid';
 
@@ -48,14 +49,14 @@ define(function (require) {
         }
 
         //this is for the initial rendering of the map
-        if (scope.layer.url) {
+        if (scope.layer.url && !utils.isXYZurl(scope.layer.url)) {
           wmsRequest(scope.layer.url);
         }
 
         //Watchers for url and getCapabilitiesSwitch equals to 0 or 1
         //this is for subsequent rendering based on changes to the wms url
         scope.$watch('layer.url', function (newUrl, oldUrl) {
-          if (newUrl !== oldUrl) {
+          if (newUrl !== oldUrl && !utils.isXYZurl(newUrl)) {
             wmsRequest(newUrl);
           }
         });

--- a/public/utils.js
+++ b/public/utils.js
@@ -120,8 +120,8 @@ define(function (require) {
       }
       return aggConfig;
     },
-    isXYZurl: function (url) {
-      if (!url) return;
+    isXyzUrl: function (url) {
+      if (!url) return false;
       const urlLowerCase = url.toLowerCase();
       return urlLowerCase.includes('{x}') && urlLowerCase.includes('{y}') && urlLowerCase.includes('{z}');
     },

--- a/public/utils.js
+++ b/public/utils.js
@@ -120,6 +120,11 @@ define(function (require) {
       }
       return aggConfig;
     },
+    isXYZurl: function (url) {
+      if (!url) return;
+      const urlLowerCase = url.toLowerCase();
+      return urlLowerCase.includes('{x}') && urlLowerCase.includes('{y}') && urlLowerCase.includes('{z}');
+    },
     /*
      * @param rect {Array of Array(lat, lon)} grid rectangle
      * created from KIBANA_HOME/src/ui/public/agg_response/geo_json/rows_to_features.js

--- a/public/visController.js
+++ b/public/visController.js
@@ -642,10 +642,12 @@ define(function (require) {
               const urlLowerCase = layerParams.url.toLowerCase();
               if (urlLowerCase.includes('{x}') && urlLowerCase.includes('{y}') && urlLowerCase.includes('{z}')) { // checking for XYZ tile server
                 layerParams.url = layerParams.url;
+                layerParams.type = 'xyz';
               } else if (layerParams.url.substr(layerParams.url.length - 5).toLowerCase() !== '/wms?') {
                 layerParams.url = layerParams.url + '/wms?';
+                layerParams.type = 'wms';
               }
-              return map.addWmsOverlay(layerParams.url, name, wmsOptions, options, layerParams.id);
+              return map.addWmsOverlay(layerParams.url, name, wmsOptions, options, layerParams.id, layerParams.type, notify);
             });
         });
       });

--- a/public/visController.js
+++ b/public/visController.js
@@ -550,6 +550,19 @@ define(function (require) {
       }
 
       $scope.vis.params.overlays.wmsOverlays.map(function (layerParams) {
+
+        let enabled = true;
+        if ($scope.flags.isVisibleSource === 'visParams') {
+          enabled = layerParams.isVisible;
+        } else if (uiState.get(layerParams.id) === false) {
+          enabled = false;
+        }
+        const options = {
+          enabled,
+          nonTiled: _.get(layerParams, 'nonTiled', false)
+        };
+
+
         // const prevState = map.clearLayerAndReturnPrevState(layerParams.id);
         const wmsIndexId = _.get(layerParams, 'indexId', getIndexPatternId());
         return indexPatterns.get(wmsIndexId).then(function (indexPattern) {
@@ -628,29 +641,18 @@ define(function (require) {
                 wmsOptions.format_options = formatOptions;
               }
 
-              let enabled;
-              if ($scope.flags.isVisibleSource === 'visParams') {
-                enabled = layerParams.isVisible;
-              }
-              $scope.flags.visibleSource = '';
-
-              const options = {
-                enabled,
-                nonTiled: _.get(layerParams, 'nonTiled', false)
-              };
-
-              const urlLowerCase = layerParams.url.toLowerCase();
-              if (urlLowerCase.includes('{x}') && urlLowerCase.includes('{y}') && urlLowerCase.includes('{z}')) { // checking for XYZ tile server
+              layerParams.type = 'wms';
+              if (utils.isXYZurl(layerParams.url)) {
                 layerParams.url = layerParams.url;
                 layerParams.type = 'xyz';
               } else if (layerParams.url.substr(layerParams.url.length - 5).toLowerCase() !== '/wms?') {
                 layerParams.url = layerParams.url + '/wms?';
-                layerParams.type = 'wms';
               }
               return map.addWmsOverlay(layerParams.url, name, wmsOptions, options, layerParams.id, layerParams.type, notify);
             });
         });
       });
+      $scope.flags.isVisibleSource = '';
     }
 
     function _updateCurrentMapEnvironment() {

--- a/public/visController.js
+++ b/public/visController.js
@@ -642,7 +642,7 @@ define(function (require) {
               }
 
               layerParams.type = 'wms';
-              if (utils.isXYZurl(layerParams.url)) {
+              if (utils.isXyzUrl(layerParams.url)) {
                 layerParams.url = layerParams.url;
                 layerParams.type = 'xyz';
               } else if (layerParams.url.substr(layerParams.url.length - 5).toLowerCase() !== '/wms?') {

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -292,30 +292,40 @@ define(function (require) {
       this._layerControl.addOverlays([this._filters]);
     };
 
-    TileMapMap.prototype.addWmsOverlay = function (url, name, wmsOptions, options, id) {
+    TileMapMap.prototype.addWmsOverlay = function (url, name, wmsOptions, options, id, type, notify) {
 
       let overlay = null;
-      if (options.nonTiled) {
-        overlay = new L.NonTiledLayer.WMS(url, wmsOptions);
-      } else {
-        overlay = L.tileLayer.wms(url, wmsOptions);
+      if (type === 'wms') {
+        if (options.nonTiled) {
+          overlay = new L.NonTiledLayer.WMS(url, wmsOptions);
+        } else {
+          overlay = L.tileLayer.wms(url, wmsOptions);
+        }
+      } else if (type === 'xyz') {
+        if (options.nonTiled) {
+          notify.error('Non-Tiled option detected: not supported with XYZ tile layers');
+        } else {
+          overlay = L.tileLayer(url, wmsOptions);
+        }
       }
 
-      overlay.layerOptions = options;
-      overlay.id = id;
-      overlay.type = 'wms';
-      overlay.label = name;
-      overlay.icon = `<i class="fas fa-map" style="color:#000000;"></i>`;
-      overlay.visible = true;
+      if (overlay) {
+        overlay.layerOptions = options;
+        overlay.id = id;
+        overlay.type = 'wms';
+        overlay.label = name;
+        overlay.icon = `<i class="fas fa-map" style="color:#000000;"></i>`;
+        overlay.visible = true;
 
-      const presentInUiState = this.uiState.get(id);
-      if (presentInUiState || options.enabled) {
-        overlay.enabled = true;
-      } else if (presentInUiState === false) {
-        overlay.enabled = false;
+        const presentInUiState = this.uiState.get(id);
+        if (presentInUiState || options.enabled) {
+          overlay.enabled = true;
+        } else if (presentInUiState === false) {
+          overlay.enabled = false;
+        }
+
+        this._layerControl.addOverlays([overlay], options);
       }
-
-      this._layerControl.addOverlays([overlay], options);
     };
 
     TileMapMap.prototype.mapBounds = function () {

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -316,13 +316,7 @@ define(function (require) {
         overlay.label = name;
         overlay.icon = `<i class="fas fa-map" style="color:#000000;"></i>`;
         overlay.visible = true;
-
-        const presentInUiState = this.uiState.get(id);
-        if (presentInUiState || options.enabled) {
-          overlay.enabled = true;
-        } else if (presentInUiState === false) {
-          overlay.enabled = false;
-        }
+        overlay.enabled = options.enabled;
 
         this._layerControl.addOverlays([overlay], options);
       }


### PR DESCRIPTION
Tried xyz's from here - https://leaflet-extras.github.io/leaflet-providers/preview/
WMS requests from my own geoserver
mapbox xyz request - https://api.mapbox.com/styles/v1/mapbox/satellite-v9/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoiZW5nY29kYSIsImEiOiJjanVxcGEzemcyOTZ3M3pueDg5b3Vzc25hIn0.59azAbNI5tb-JWyLp5RgKw

GetCapabilities request NOT fired for XYZ layer types
Toast for when XYZ url is detected with non-tiled layer type

There are optimisations that could be done to reduce network requests

![MapBoxTilesWorking](https://user-images.githubusercontent.com/36197976/85853226-0e45cc00-b7aa-11ea-9c46-fcf5ebd51966.gif)


