### PR TITLE
Restyling polygon borders and fill type

### DIFF
--- a/public/vislib/vector_layer_types/EsLayer.js
+++ b/public/vislib/vector_layer_types/EsLayer.js
@@ -107,11 +107,10 @@ export default class EsLayer {
             },
             style: {
               fillColor: options.color || '#8510d8',
-              weight: 2,
-              opacity: 1,
-              color: options.color || '#000000',
-              dashArray: '3',
-              fillOpacity: 0.75
+              weight: 1,
+              opacity: 0.6,
+              color: '#444444',
+              fillOpacity: 0.6
             },
             destroy: function onEachFeature(feature, polygon) {
               if (feature && options.leafletMap._popup) {
@@ -170,18 +169,16 @@ export default class EsLayer {
 
       if (geo.type === 'point' || geo.type === 'geo_point') {
         layer.icon = `<i class="${options.icon}" style="color:${options.color};"></i>`;
+        layer.type = type + '_point';
       } else if (geo.type === 'line') {
         layer.icon = `<i class="far fa-horizontal-rule" style="color:${options.color};"></i>`;
+        layer.type = type + '_shape';
       } else {
         layer.icon = `<i class="far fa-draw-square" style="color:${options.color};"></i>`;
+        layer.type = type + '_shape';
       }
 
       layer.options = { pane: 'overlayPane' };
-      if (geo.type === 'point') {
-        layer.type = type + '_point';
-      } else {
-        layer.type = type + '_shape';
-      }
 
       layer.visible = options.visible || true;
       return layer;

--- a/public/vislib/vector_layer_types/EsLayer.js
+++ b/public/vislib/vector_layer_types/EsLayer.js
@@ -107,9 +107,9 @@ export default class EsLayer {
             },
             style: {
               fillColor: options.color || '#8510d8',
-              weight: 1,
+              weight: self.isLine(geo.type) ? 2 : 1,
               opacity: 0.6,
-              color: '#444444',
+              color: self.isLine(geo.type) ? options.color : '#444444',
               fillOpacity: 0.6
             },
             destroy: function onEachFeature(feature, polygon) {
@@ -183,6 +183,11 @@ export default class EsLayer {
       layer.visible = options.visible || true;
       return layer;
     }
+  }
+
+  isLine = function (type) {
+    if (!type) return false;
+    return type === 'linestring' || type === 'multilinestring';
   }
 
   assignFeatureLevelConfigurations = function (hit, type, options) {


### PR DESCRIPTION
Also accommodated are lines. The border color of a polygon (now grey-ish) is the same as the color of the actual line (now the configured color). Ternary functions determine the geometry type. 

I chose the slim grey line for polygon borders because it's similar to the QGIS default and I've found it to be easy to work with in the past. 

Previously:
![image](https://user-images.githubusercontent.com/36197976/85866996-2cb6c200-b7c0-11ea-8e99-1cac0d6f36be.png)

With this PR:
![image](https://user-images.githubusercontent.com/36197976/85867086-4bb55400-b7c0-11ea-873b-0a6e83a28faf.png)
