### PR TITLE
Redraw layer if too many document drawing on previous extent

### DIFF
--- a/public/__tests__/utils.js
+++ b/public/__tests__/utils.js
@@ -250,6 +250,22 @@ describe('Kibi Enhanced Tilemap', () => {
         }
       });
 
+      it('zoom IN documents with/without warning on previous extent check', () => {
+        const layerParams = zoomInFromStartingState.layerParams; // layer parameters including zoom, precision and map bounds of the last successful fetch
+        layerParams.enabled = true; // always enabled, this way the other factors determine the result
+        layerParams.type = 'es_ref_shape';
+
+        const _currentMapBounds = zoomInFromStartingState.mapBounds; // the new zoomed in map extent is INSIDE the bounds that the layer has data fetched for
+
+        const zoom = 6;
+        const precision = aggPrecision[zoom];
+
+        [true, false].forEach(warning => { // true means there were too many documents to show on previous map extent
+          const result = utils.drawLayerCheck(layerParams, _currentMapBounds, zoom, precision, warning);
+          expect(result).to.be(warning);
+        });
+      });
+
       it('should redraw because map zoomed outside of collar', () => {
         const layerParams = zoomOutFromStartingState.layerParams; // layer parameters including zoom, precision and map bounds of the last successful fetch
         const _currentMapBounds = zoomOutFromStartingState.mapBounds; // the new zoomed in map extent is INSIDE the bounds that the layer has data fetched for
@@ -263,7 +279,7 @@ describe('Kibi Enhanced Tilemap', () => {
         expect(result).to.be(true);
       });
 
-      it('should redraw becase map is panned outside of current map bounds check', () => {
+      it('should redraw because map is panned outside of current map bounds check', () => {
         const layerParams = panOutsideOfStartingStateCollar.layerParams; // layer parameters including zoom, precision and map bounds of the last successful fetch
         const _currentMapBounds = panOutsideOfStartingStateCollar.mapBounds; // the new zoomed in map extent is INSIDE the bounds that the layer has data fetched for
         layerParams.enabled = true; // always enabled, this way the other factors determine the result

--- a/public/lib/dragAndDroplayercontrol/DndLayerControl.js
+++ b/public/lib/dragAndDroplayercontrol/DndLayerControl.js
@@ -681,7 +681,7 @@ function getExtendedMapControl() {
   }
 
   function getLayerById(id) {
-    return find(_allLayers, layer => layer.id === id);
+    return find(_allLayers, { id });
   }
 
   function removeAllLayersFromMapandControl() {

--- a/public/lib/dragAndDroplayercontrol/DndLayerControl.js
+++ b/public/lib/dragAndDroplayercontrol/DndLayerControl.js
@@ -1,6 +1,6 @@
 /* eslint-disable siren/memory-leak */
 
-import { debounce, remove, get, findIndex, pick, cloneDeep } from 'lodash';
+import { debounce, remove, get, findIndex, pick, cloneDeep, find } from 'lodash';
 import React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { showAddLayerTreeModal } from './layerContolTree';
@@ -340,10 +340,13 @@ function getExtendedMapControl() {
   }
 
   function _storedLayerRedrawCheck(visibleForCurrentMapZoom, item) {
+    const warning = getLayerById(item.id).warning;
+
     return visibleForCurrentMapZoom && (!item.mapParams.visible || utils.drawLayerCheck(item,
       _currentMapEnvironment.currentMapBounds,
       _currentMapEnvironment.currentZoom,
-      _currentMapEnvironment.currentPrecision));
+      _currentMapEnvironment.currentPrecision,
+      warning));
   }
 
   async function getEsRefLayer(spatialPath, enabled, config) {
@@ -677,6 +680,10 @@ function getExtendedMapControl() {
     }
   }
 
+  function getLayerById(id) {
+    return find(_allLayers, layer => layer.id === id);
+  }
+
   function removeAllLayersFromMapandControl() {
     _clearAllLayersFromMap();
     _allLayers = [];
@@ -738,6 +745,7 @@ function getExtendedMapControl() {
     _makeExistsForConfigFieldTypes,
     getPathList, // retrieves a list of spatial paths from indices with a .map__ prefix
     loadSavedStoredLayers, //checks the uiState for stored layers and draws the ones that are present
+    getLayerById,
 
     getAllLayers: () => {
       return _allLayers;

--- a/public/utils.js
+++ b/public/utils.js
@@ -325,12 +325,12 @@ define(function (require) {
       }
       return { aggFeatures, docFilters };
     },
-    drawLayerCheck: function (layerParams, mapBounds, zoom, precision) {
+    drawLayerCheck: function (layerParams, mapBounds, zoom, precision, warning = false) {
       if (!layerParams.mapParams || !layerParams.type || !mapBounds || !zoom || !precision) return true;
 
       const zoomLevelCheck = (
-        // no need to redraw shapes when zooming in
-        zoom < layerParams.mapParams.zoomLevel && (
+        // no need to redraw shapes when zooming in, unless the limit was exceeded on the last time layer was created
+        ((warning && zoom > layerParams.mapParams.zoomLevel) || zoom < layerParams.mapParams.zoomLevel) && (
           layerParams.type === 'es_ref_shape' ||
           layerParams.type === 'poi_shape')
       ) ||

--- a/public/visController.js
+++ b/public/visController.js
@@ -320,11 +320,14 @@ define(function (require) {
           layerParams.enabled = true;
         }
 
+        const warning = map._layerControl.getLayerById(layerParams.id).warning;
+
         if ((queryFilterChange && layerParams.enabled) ||
           utils.drawLayerCheck(layerParams,
             _currentMapEnvironment.currentMapBounds,
             _currentMapEnvironment.currentZoom,
-            _currentMapEnvironment.currentClusteringPrecision)) {
+            _currentMapEnvironment.currentClusteringPrecision,
+            warning)) {
           initPOILayer(layerParams);
         }
       });
@@ -862,12 +865,14 @@ define(function (require) {
 
       if (e.layerType === 'poi_shape' || e.layerType === 'poi_point') {
         const layerParams = getPoiLayerParamsById(e.id);
+        const warning = map._layerControl.getLayerById(e.id).warning;
         layerParams.enabled = e.enabled;
         layerParams.type = e.layerType;
         if (utils.drawLayerCheck(layerParams,
           _currentMapEnvironment.currentMapBounds,
           _currentMapEnvironment.currentZoom,
-          _currentMapEnvironment.currentClusteringPrecision)) {
+          _currentMapEnvironment.currentClusteringPrecision,
+          warning)) {
           initPOILayer(layerParams);
         }
       } else if (e.layerType === 'agg') {


### PR DESCRIPTION
With this PR, if the previous zoom extent had too many documents to be drawn on the map, the layer will be re-rendered when zooming in.

This applies to polygon and line type layers. 

Fix for - https://sirensolutions.atlassian.net/browse/INVE-11993 

![image](https://user-images.githubusercontent.com/36197976/85875481-2c242880-b7cc-11ea-9b82-6784de31e952.png)



