### PR TITLE
POI buffer filters for points fixed post marker clustering

### DIFF
--- a/public/callbacks.js
+++ b/public/callbacks.js
@@ -4,7 +4,6 @@ define(function (require) {
   return function CallbacksFactory(Private) {
     const _ = require('lodash');
     const geoFilter = Private(require('plugins/enhanced_tilemap/vislib/geoFilter'));
-    const utils = require('plugins/enhanced_tilemap/utils');
     const L = require('leaflet');
 
     return {
@@ -31,19 +30,6 @@ define(function (require) {
             }
           });
         });
-      },
-      fetchSearchSource: async function (event) {
-        //Fetch new data if map bounds are outsize of collar
-        const bounds = utils.geoBoundingBoxBounds(event.mapBounds, 1);
-        const autoPrecision = _.get(event, 'chart.geohashGridAgg.params.autoPrecision');
-        const previousZoom = _.get(event, 'chart.geoJson.properties.zoom');
-        if (_.has(event, 'collar.top_left')) {
-          if (autoPrecision && (event.currentZoom !== previousZoom || !utils.contains(event.collar, bounds))) {
-            return event.searchSource.fetch();
-          } else if (!autoPrecision && !utils.contains(event.collar, bounds))  {
-            return event.searchSource.fetch();
-          }
-        }
       },
       poiFilter: function (event) {
 

--- a/public/lib/dragAndDroplayercontrol/DndLayerControl.js
+++ b/public/lib/dragAndDroplayercontrol/DndLayerControl.js
@@ -756,6 +756,14 @@ function getExtendedMapControl() {
       return _allLayers;
     },
 
+    mapHasLayerType: (type) => {
+      return findIndex(_allLayers, layer => layer.type.includes(type)) !== -1;
+    },
+
+    mapHasCluster: () => {
+      return findIndex(_allLayers, layer => layer.hasCluster) !== -1;
+    },
+
     onAdd: function (map) {
       const debouncedHandler = debounce(() => {
         _redrawEsRefLayers();

--- a/public/lib/dragAndDroplayercontrol/DndLayerControl.js
+++ b/public/lib/dragAndDroplayercontrol/DndLayerControl.js
@@ -1,6 +1,6 @@
 /* eslint-disable siren/memory-leak */
 
-import { debounce, remove, get, findIndex, pick, cloneDeep, find } from 'lodash';
+import { debounce, remove, get, findIndex, pick, cloneDeep, find, size } from 'lodash';
 import React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { showAddLayerTreeModal } from './layerContolTree';
@@ -762,6 +762,16 @@ function getExtendedMapControl() {
 
     mapHasCluster: () => {
       return findIndex(_allLayers, layer => layer.hasCluster) !== -1;
+    },
+
+    totalNumberOfPointsOnMap: () => {
+      let count = 0;
+      _allLayers.forEach(layer => {
+        if (layer.type.includes('point')) {
+          count += size(layer._layers);
+        }
+      });
+      return count;
     },
 
     onAdd: function (map) {

--- a/public/lib/dragAndDroplayercontrol/DndLayerControl.js
+++ b/public/lib/dragAndDroplayercontrol/DndLayerControl.js
@@ -767,7 +767,7 @@ function getExtendedMapControl() {
     totalNumberOfPointsOnMap: () => {
       let count = 0;
       _allLayers.forEach(layer => {
-        if (layer.type.includes('point')) {
+        if (layer.type.endsWith('point')) {
           count += size(layer._layers);
         }
       });

--- a/public/visController.js
+++ b/public/visController.js
@@ -365,7 +365,7 @@ define(function (require) {
       };
 
       poi.getLayer(options, function (layer) {
-        map.addPOILayer(layer);
+        map.addFeatureLayer(layer);
       });
     }
 
@@ -399,7 +399,7 @@ define(function (require) {
 
       const layer = new Vector(geoJsonCollection).getLayer(optionsWithDefaults);
       layer.id = id;
-      map.addVectorLayer(layer, optionsWithDefaults);
+      map.addFeatureLayer(layer, optionsWithDefaults);
 
     }
 
@@ -997,8 +997,9 @@ define(function (require) {
 
     map.leafletMap.on('toolbench:poiFilter', function (e) {
       const poiLayers = [];
-      map.allLayers.forEach(layer => {
-        if (layer.type === 'poi') {
+      const allLayers = map._layerControl.getAllLayers();
+      allLayers.forEach(layer => {
+        if (layer.type.includes('point') && !layer.hasClusters && _.size(layer._layers) <= 100) {
           poiLayers.push(layer);
         }
       });

--- a/public/visController.js
+++ b/public/visController.js
@@ -999,7 +999,7 @@ define(function (require) {
       const poiLayers = [];
       const allLayers = map._layerControl.getAllLayers();
       allLayers.forEach(layer => {
-        if (layer.type.includes('point') && !layer.hasClusters && _.size(layer._layers) <= 100) {
+        if (layer.type.includes('point') && !layer.hasClusters && map._layerControl.totalNumberOfPointsOnMap() <= 80) {
           poiLayers.push(layer);
         }
       });

--- a/public/visController.js
+++ b/public/visController.js
@@ -999,7 +999,7 @@ define(function (require) {
       const poiLayers = [];
       const allLayers = map._layerControl.getAllLayers();
       allLayers.forEach(layer => {
-        if (layer.type.includes('point') && !layer.hasClusters && map._layerControl.totalNumberOfPointsOnMap() <= 80) {
+        if (layer.type.endsWith('point') && !layer.hasClusters && map._layerControl.totalNumberOfPointsOnMap() <= 80) {
           poiLayers.push(layer);
         }
       });

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -208,28 +208,15 @@ define(function (require) {
       this._layerControl.removeLayerFromMapAndControlById(id);
     };
 
-    TileMapMap.prototype.addPOILayer = function (layer) {
+    TileMapMap.prototype.addFeatureLayer = function (layer) {
       const id = layer.id;
       if (this.uiState.get(id) || this.uiState.get(id) === undefined) layer.enabled = true;
       this._layerControl.addOverlays([layer]);
 
-      //Add tool to l.draw.toolbar so users can filter by POIs
-      if (Object.keys(this.allLayers).length === 1) {
-        if (this._toolbench) this._toolbench.removeTools();
-        if (!this._toolbench) this._addDrawControl();
-        this._toolbench.addTool();
-      }
-    };
-
-    TileMapMap.prototype.addVectorLayer = function (layer) {
-      const id = layer.id;
-      layer.enabled = this.uiState.get(id) || true;
-      this._layerControl.addOverlays([layer]);
-
       //Add tool to l.draw.toolbar so users can filter by vector layers
-      if (Object.keys(this.allLayers).length === 1) {
-        if (this._toolbench) this._toolbench.removeTools();
-        if (!this._toolbench) this._addDrawControl();
+      if (this._toolbench) this._toolbench.removeTools();
+      if (!this._toolbench) this._addDrawControl();
+      if (this._layerControl.mapHasLayerType('point') && !this._layerControl.mapHasCluster()) {
         this._toolbench.addTool();
       }
     };
@@ -408,16 +395,6 @@ define(function (require) {
 
     TileMapMap.prototype._attachEvents = function () {
       const self = this;
-
-      this.leafletMap.on('removeLayer', (e) => {
-        const id = e.layerId;
-        if (_.has(this.allLayers, id)) {
-          const layer = this.allLayers[id];
-          this.allLayers[id].destroy();
-          this.leafletMap.removeLayer(layer);
-          delete this.allLayers[id];
-        }
-      });
 
       this.leafletMap.on('etm:select-feature-vector', function (e) {
         self._callbacks.polygonVector({

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -216,7 +216,9 @@ define(function (require) {
       //Add tool to l.draw.toolbar so users can filter by vector layers
       if (this._toolbench) this._toolbench.removeTools();
       if (!this._toolbench) this._addDrawControl();
-      if (this._layerControl.mapHasLayerType('point') && !this._layerControl.mapHasCluster()) {
+      if (this._layerControl.mapHasLayerType('point') &&
+        !this._layerControl.mapHasCluster() &&
+        this._layerControl.totalNumberOfPointsOnMap() <= 80) {
         this._toolbench.addTool();
       }
     };

--- a/public/vislib/vector_layer_types/EsLayer.js
+++ b/public/vislib/vector_layer_types/EsLayer.js
@@ -33,6 +33,7 @@ export default class EsLayer {
         layer.type = type + '_point';
         layer.options = { pane: 'overlayPane' };
         layer.icon = `<i class="${layerControlIcon}" style="color:${layerControlColor};"></i>`;
+        layer.hasCluster = aggs.length >= 1;
         layer.destroy = () => {
           layer.unbindPopup();
         };


### PR DESCRIPTION
Icon to create point buffer filter now appears when: 
* There are less than 100 point documents (in total) on the map
* There are no clusters present on the map

Filters are only created for the points that are visible on the map. 

Jarek, for manual test, you can set the map collar to 1 to make things easier. 

![POIFiltersWorking](https://user-images.githubusercontent.com/36197976/86390647-5c6a3c00-bc90-11ea-8cdd-f6cb6f9b18d2.gif)
