### PR TITLE
Fixing too many documents layer control warning icon

### DIFF
--- a/public/lib/dragAndDroplayercontrol/DndLayerControl.js
+++ b/public/lib/dragAndDroplayercontrol/DndLayerControl.js
@@ -238,7 +238,22 @@ function getExtendedMapControl() {
     remove(esRefLayersOnMap, (layer) => layer.path === path);
   }
 
+  function _someLayerHasTooManyDocumentsWarning() {
+    return findIndex(_allLayers, layer => layer.warning) !== -1;
+  }
+
   function _updateLayerControl() {
+    const $layerControl = $element.find('.leaflet-control-layers');
+    const $warningElement = get($layerControl, '[0].children[0]');
+    if ($warningElement) {
+      if (_someLayerHasTooManyDocumentsWarning()) {
+        $layerControl.addClass('leaflet-control-layers-warning');
+        $warningElement.innerHTML = '<i class="fa fa-exclamation-triangle text-color-warning doc-viewer-underscore"></i>';
+      } else {
+        $layerControl.removeClass('leaflet-control-layers-warning');
+        $warningElement.innerHTML = '';
+      }
+    }
     render(<LayerControlDnd
       dndCurrentListOrder={_allLayers}
       dndListOrderChange={dndListOrderChange}

--- a/public/visController.js
+++ b/public/visController.js
@@ -364,7 +364,6 @@ define(function (require) {
         mainVisGeoFieldName: getGeoField().fieldname,
         geoFieldName: layerParams.geoField,
         searchSource: $scope.searchSource,
-        $element,
         leafletMap: map.leafletMap,
         zoom: map.leafletMap.getZoom()
       };

--- a/public/vislib/vector_layer_types/EsLayer.js
+++ b/public/vislib/vector_layer_types/EsLayer.js
@@ -11,13 +11,8 @@ export default class EsLayer {
 
 
   createLayer = function (hits, aggs, geo, type, options) {
-    const layerControl = options.$element.find('.leaflet-control-layers');
     let layer = null;
     const self = this;
-
-    options.$legend = options.$element.find('a.leaflet-control-layers-toggle').get(0);
-    options.$legend.innerHTML = '';
-    layerControl.removeClass('leaflet-control-layers-warning');
 
     if ((aggs && aggs.length >= 1) || hits.length >= 1) {
       //using layer level config
@@ -128,9 +123,6 @@ export default class EsLayer {
         );
         self.bindPopup(layer, options);
         if (options.warning && options.warning.limit) {
-          //handling too many documents warnings
-          layerControl.addClass('leaflet-control-layers-warning');
-          options.$legend.innerHTML = `<i class="fa fa-exclamation-triangle text-color-warning doc-viewer-underscore"></i>`;
           layer.warning = `There are undisplayed POIs for this overlay due
         to having reached the limit currently set to ${options.warning.limit}`;
         }


### PR DESCRIPTION
Before the warning icon drew and was then removed if a subsequent layer was drawn. Now each time an overlay is added, there is warning check and the icons is added or removed if necessary:
![FixForWarningIcon](https://user-images.githubusercontent.com/36197976/87695554-8723bc80-c787-11ea-8a64-10c00b8a8b03.gif)
