### PR TITLE
Retaining dashboard time while panning/zooming the map

### DIFF
--- a/public/__tests__/utils.js
+++ b/public/__tests__/utils.js
@@ -111,12 +111,6 @@ describe('Kibi Enhanced Tilemap', () => {
 
         [
           {
-            description: 'no time filter on dashboard or layer',
-            layerParamsTimeFilter: undefined,
-            currentDashboardTimeFilter: undefined,
-            result: true
-          },
-          {
             description: 'time filter on dashboard but no time filter stored in layer',
             layerParamsTimeFilter: undefined,
             currentDashboardTimeFilter: 'there is a time filter on dashboard',

--- a/public/__tests__/utils.js
+++ b/public/__tests__/utils.js
@@ -99,16 +99,7 @@ describe('Kibi Enhanced Tilemap', () => {
         });
       });
 
-      it('time filter draw checks', () => {
-        const layerParams = zoomInFromStartingState.layerParams; // layer parameters including zoom, precision and map bounds of the last successful fetch
-        layerParams.enabled = true; // always enabled, this way the other factors determine the result
-        layerParams.type = 'es_ref_shape';
-
-        // The same as stored in layer, this way time will determine result
-        const _currentMapBounds = zoomInFromStartingState.layerParams.mapParams.mapBounds;
-        const zoom = zoomInFromStartingState.layerParams.mapParams.zoomLevel;
-        const precision = zoomInFromStartingState.layerParams.mapParams.precision;
-
+      describe('Time filter draw checks', () => {
         [
           {
             description: 'time filter on dashboard but no time filter stored in layer',
@@ -157,11 +148,22 @@ describe('Kibi Enhanced Tilemap', () => {
             result: true
           }
         ].forEach(scenario => {
-          layerParams.currentTimeFilter = scenario.layerParamsTimeFilter;
-          const result = utils.drawLayerCheck(layerParams, _currentMapBounds, zoom, precision, null, scenario.currentDashboardTimeFilter);
-          expect(result).to.be(scenario.result);
-        });
+          it(`${scenario.description}`, () => {
+            const layerParams = zoomInFromStartingState.layerParams; // layer parameters including zoom, precision and map bounds of the last successful fetch
+            layerParams.enabled = true; // always enabled, this way the other factors determine the result
+            layerParams.type = 'es_ref_shape';
 
+            // The same as stored in layer, this way time will determine result
+            const _currentMapBounds = zoomInFromStartingState.layerParams.mapParams.mapBounds;
+            const zoom = zoomInFromStartingState.layerParams.mapParams.zoomLevel;
+            const precision = zoomInFromStartingState.layerParams.mapParams.precision;
+
+
+            layerParams.currentTimeFilter = scenario.layerParamsTimeFilter;
+            const result = utils.drawLayerCheck(layerParams, _currentMapBounds, zoom, precision, null, scenario.currentDashboardTimeFilter);
+            expect(result).to.be(scenario.result);
+          });
+        });
       });
 
       it('should redraw because map zoomed outside of collar', () => {

--- a/public/__tests__/utils.js
+++ b/public/__tests__/utils.js
@@ -99,6 +99,77 @@ describe('Kibi Enhanced Tilemap', () => {
         });
       });
 
+      it('time filter draw checks', () => {
+        const layerParams = zoomInFromStartingState.layerParams; // layer parameters including zoom, precision and map bounds of the last successful fetch
+        layerParams.enabled = true; // always enabled, this way the other factors determine the result
+        layerParams.type = 'es_ref_shape';
+
+        // The same as stored in layer, this way time will determine result
+        const _currentMapBounds = zoomInFromStartingState.layerParams.mapParams.mapBounds;
+        const zoom = zoomInFromStartingState.layerParams.mapParams.zoomLevel;
+        const precision = zoomInFromStartingState.layerParams.mapParams.precision;
+
+        [
+          {
+            description: 'no time filter on dashboard or layer',
+            layerParamsTimeFilter: undefined,
+            currentDashboardTimeFilter: undefined,
+            result: true
+          },
+          {
+            description: 'time filter on dashboard but no time filter stored in layer',
+            layerParamsTimeFilter: undefined,
+            currentDashboardTimeFilter: 'there is a time filter on dashboard',
+            result: true
+          },
+          {
+            description: 'same time filter in layer and on dashboard',
+            layerParamsTimeFilter: 'same time filter',
+            currentDashboardTimeFilter: 'same time filter',
+            result: false
+          },
+          {
+            description: 'different time filter on dashboard than stored in layer',
+            layerParamsTimeFilter: 'time filter from previous update',
+            currentDashboardTimeFilter: 'dashboard time has been updated',
+            result: true
+          },
+          {
+            description: 'same time filter object test, not used in other scenarios for heightened clarity',
+            layerParamsTimeFilter: {
+              range: {
+                funded_date: { gte: '1997-07-26T21:40:00.000Z', lte: '2013-11-20T23:59:00.000Z', format: 'strict_date_optional_time' }
+              }
+            },
+            currentDashboardTimeFilter: {
+              range: {
+                funded_date: { gte: '1997-07-26T21:40:00.000Z', lte: '2013-11-20T23:59:00.000Z', format: 'strict_date_optional_time' }
+              }
+            },
+            result: false
+          },
+          {
+            description: 'different time filter object test, not used in other scenarios for heightened clarity',
+            layerParamsTimeFilter: {
+              range: {
+                funded_date: { gte: '1987-07-26T21:40:00.000Z', lte: '2013-11-20T23:59:00.000Z', format: 'strict_date_optional_time' }
+              }
+            },
+            currentDashboardTimeFilter: {
+              range: {
+                funded_date: { gte: '1997-07-26T21:40:00.000Z', lte: '2013-11-20T23:59:00.000Z', format: 'strict_date_optional_time' }
+              }
+            },
+            result: true
+          }
+        ].forEach(scenario => {
+          layerParams.currentTimeFilter = scenario.layerParamsTimeFilter;
+          const result = utils.drawLayerCheck(layerParams, _currentMapBounds, zoom, precision, null, scenario.currentDashboardTimeFilter);
+          expect(result).to.be(scenario.result);
+        });
+
+      });
+
       it('should redraw because map zoomed outside of collar', () => {
         const layerParams = zoomOutFromStartingState.layerParams; // layer parameters including zoom, precision and map bounds of the last successful fetch
         const _currentMapBounds = zoomOutFromStartingState.mapBounds; // the new zoomed in map extent is INSIDE the bounds that the layer has data fetched for

--- a/public/lib/dragAndDroplayercontrol/DndLayerControl.js
+++ b/public/lib/dragAndDroplayercontrol/DndLayerControl.js
@@ -206,14 +206,16 @@ function getExtendedMapControl() {
       _leafletMap.fire('showlayer', {
         layerType: layer.type,
         id: layer.id,
-        enabled: enabled
+        enabled,
+        isDragAndDrop: layer.isDragAndDrop
       });
     } else {
       _clearLayerFromMapById(layer.id);
       _leafletMap.fire('hidelayer', {
         layerType: layer.type,
         id: layer.id,
-        enabled
+        enabled,
+        isDragAndDrop: layer.isDragAndDrop
       });
     }
     if (layer.type === 'es_ref_point' || layer.type === 'es_ref_shape') {
@@ -503,7 +505,8 @@ function getExtendedMapControl() {
         _leafletMap.fire('showlayer', {
           layerType: layer.type,
           id: layer.id,
-          enabled: layer.enabled
+          enabled: layer.enabled,
+          isDragAndDrop: layer.isDragAndDrop
         });
       }
     }
@@ -530,7 +533,8 @@ function getExtendedMapControl() {
       _leafletMap.fire('showlayer', {
         layerType: layer.type,
         id: layer.id,
-        enabled: layer.enabled
+        enabled: layer.enabled,
+        isDragAndDrop: layer.isDragAndDrop
       });
     }
     addOverlays(esRefLayerList);

--- a/public/utils.js
+++ b/public/utils.js
@@ -203,9 +203,13 @@ define(function (require) {
 
       return new L.Point(widthOffset, heightOffset);
     },
-    drawLayerCheck: function (layerParams, mapBounds, zoom, precision, warning = false, currentDashboardTimeFilter = false) {
+    drawLayerCheck: function (layerParams,
+      mapBounds,
+      zoom,
+      precision,
+      warning = false,
+      currentDashboardTimeFilter = false) {
       if (!layerParams.mapParams ||
-        !layerParams.currentTimeFilter ||
         !layerParams.type ||
         !mapBounds ||
         !zoom ||
@@ -227,7 +231,9 @@ define(function (require) {
       // current map canvas must contain the extent that the layer was rendered for
       const layerHasDataForCurrentBounds = !this.contains(layerParams.mapParams.mapBounds, mapBounds);
 
-      const timeCheck = currentDashboardTimeFilter && !(layerParams.currentTimeFilter === currentDashboardTimeFilter);
+      const timeCheck = currentDashboardTimeFilter && (!layerParams.currentTimeFilter) ||
+        (currentDashboardTimeFilter && layerParams.currentTimeFilter &&
+          (!_.isEqual(layerParams.currentTimeFilter, currentDashboardTimeFilter)));
 
       return layerParams.enabled && (zoomLevelCheck || layerHasDataForCurrentBounds || timeCheck);
     }

--- a/public/utils.js
+++ b/public/utils.js
@@ -203,8 +203,13 @@ define(function (require) {
 
       return new L.Point(widthOffset, heightOffset);
     },
-    drawLayerCheck: function (layerParams, mapBounds, zoom, precision, warning = false) {
-      if (!layerParams.mapParams || !layerParams.type || !mapBounds || !zoom || !precision) return true;
+    drawLayerCheck: function (layerParams, mapBounds, zoom, precision, warning = false, currentDashboardTimeFilter = false) {
+      if (!layerParams.mapParams ||
+        !layerParams.currentTimeFilter ||
+        !layerParams.type ||
+        !mapBounds ||
+        !zoom ||
+        !precision) return true;
 
       const zoomLevelCheck = (
         // no need to redraw shapes when zooming in, unless the limit was exceeded on the last time layer was created
@@ -222,7 +227,9 @@ define(function (require) {
       // current map canvas must contain the extent that the layer was rendered for
       const layerHasDataForCurrentBounds = !this.contains(layerParams.mapParams.mapBounds, mapBounds);
 
-      return layerParams.enabled && (zoomLevelCheck || layerHasDataForCurrentBounds);
+      const timeCheck = currentDashboardTimeFilter && !(layerParams.currentTimeFilter === currentDashboardTimeFilter);
+
+      return layerParams.enabled && (zoomLevelCheck || layerHasDataForCurrentBounds || timeCheck);
     }
   };
 });

--- a/public/visController.js
+++ b/public/visController.js
@@ -207,7 +207,10 @@ define(function (require) {
           };
           dragAndDropPoiLayer.savedDashboardTitle = savedDashboard.lastSavedTitle;
           dragAndDropPoiLayer.isInitialDragAndDrop = true;
-          if (!dragAndDropPoiLayer.id) dragAndDropPoiLayer.id = uuid.v1();
+          if (!dragAndDropPoiLayer.id)  {
+            dragAndDropPoiLayer.id = uuid.v1();
+            sirenSessionState.set(dragAndDropPoiLayer.id, true);
+          }
           dragAndDropPoiLayer.limit = 250;
           dragAndDropPoiLayer.isDragAndDrop = true;
           // initialize on drop

--- a/public/visController.js
+++ b/public/visController.js
@@ -504,6 +504,7 @@ define(function (require) {
     $rootScope.$on('courier:searchRefresh', () => drawLayersFromQueryOrTimeFilterUpdate());
 
     async function drawLayersFromQueryOrTimeFilterUpdate() {
+      if (!map.leafletMap) return;
       await setTooltipFormatter($scope.vis.params.tooltip, $scope.vis._siren);
       _updateCurrentTimeFilter();
       setCurrentTimeFilter($scope.searchSource);

--- a/public/visController.js
+++ b/public/visController.js
@@ -45,6 +45,7 @@ define(function (require) {
     const BoundsHelper = Private(require('plugins/enhanced_tilemap/vislib/DataBoundsHelper'));
     let collar = null;
     let chartData = null;
+    let _currentTimeFilter;
     let map = null;
     let tooltip = null;
     let tooltipFormatter = null;
@@ -78,6 +79,8 @@ define(function (require) {
       modifyToDsl();
       await setTooltipFormatter($scope.vis.params.tooltip, $scope.vis._siren);
       drawWfsOverlays();
+      _updateCurrentTimeFilter();
+      $scope.searchSource.vis.currentTimeFilter = _.cloneDeep(timefilter.get($scope.vis.indexPattern));
       await drawLayers();
 
       if (_shouldAutoFitMapBoundsToData(true)) {
@@ -165,8 +168,12 @@ define(function (require) {
       return !!field;
     }
 
-    function getPoiLayerParamsById(id) {
-      return _.find($scope.vis.params.overlays.savedSearches, { id });
+    function getPoiLayerParamsById(id, isDragAndDrop) {
+      if (isDragAndDrop) {
+        return _.find($scope.vis.params.overlays.dragAndDropPoiLayers, { id });
+      } else {
+        return _.find($scope.vis.params.overlays.savedSearches, { id });
+      }
     }
 
     async function addPOILayerFromDashboardWithModal(dashboardId) {
@@ -178,7 +185,7 @@ define(function (require) {
           const dashCounts = {};
           dashCounts[dashboardId] = dash.count;
 
-          const savedDashboard = await savedDashboards.get(dashboardId);
+          const savedDashboard = await getDashboard(dashboardId);
           const savedSearchId = savedDashboard.getMainSavedSearchId();
           const hasGeofield = await searchHasGeofield(savedSearchId);
 
@@ -199,10 +206,10 @@ define(function (require) {
             savedSearchId: savedSearchId
           };
           dragAndDropPoiLayer.savedDashboardTitle = savedDashboard.lastSavedTitle;
-          dragAndDropPoiLayer.layerGroup = '<b> Drag and Drop Overlays </b>';
           dragAndDropPoiLayer.isInitialDragAndDrop = true;
           if (!dragAndDropPoiLayer.id) dragAndDropPoiLayer.id = uuid.v1();
           dragAndDropPoiLayer.limit = 250;
+          dragAndDropPoiLayer.isDragAndDrop = true;
           // initialize on drop
           initPOILayer(dragAndDropPoiLayer);
 
@@ -292,6 +299,17 @@ define(function (require) {
       return filter;
     }
 
+    function _updateCurrentTimeFilter() {
+      _currentTimeFilter = timefilter.get($scope.vis.indexPattern);
+    }
+
+    function setCurrentTimeFilter(searchSource) {
+      if (!searchSource.vis) {
+        searchSource.vis = $scope.vis;
+      }
+      searchSource.vis.currentTimeFilter = _currentTimeFilter;
+    }
+
     function getMapBounds() {
       return utils.geoBoundingBoxBounds(map.mapBounds(), 1);
     }
@@ -312,6 +330,28 @@ define(function (require) {
 
     function saturateWMSTile(layer) {
       map.saturateTile($scope.vis.params.isDesaturated, layer);
+    }
+
+    async function getDashboard(dashboardId) {
+      return await savedDashboards.get(dashboardId);
+    }
+
+    function _getDefaultVectorLayerOptions(layerParams, displayName, id) {
+      return {
+        color: _.get(layerParams, 'color', '#008800'),
+        displayName,
+        id,
+        leafletMap: map.leafletMap,
+        mainVisGeoFieldName: getGeoField().fieldname,
+        mapExtentFilter: {
+          geo_bounding_box: getGeoBoundingBox(),
+          geoField: getGeoField()
+        },
+        searchSource: $scope.searchSource,
+        _siren: getSirenMeta(),
+        size: _.get(layerParams, 'markerSize', 'm'),
+        vis: $scope.vis,
+      };
     }
 
     function _drawPoiLayers(poiLayerArray, queryFilterChange) {
@@ -341,7 +381,8 @@ define(function (require) {
             _currentMapEnvironment.currentMapBounds,
             _currentMapEnvironment.currentZoom,
             _currentMapEnvironment.currentClusteringPrecision,
-            warning)) {
+            warning,
+            _currentTimeFilter)) {
           initPOILayer(layerParams);
         }
       });
@@ -356,23 +397,17 @@ define(function (require) {
         precision: getMarkerClusteringPrecision(_currentMapEnvironment.currentZoom),
         mapBounds: getMapBoundsWithCollar()
       };
+      layerParams.currentTimeFilter = _currentTimeFilter;
 
       const options = {
-        vis: $scope.vis,
-        dsl: $scope.vis.aggs.toDsl(),
-        id: layerParams.id,
-        displayName,
-        color: layerParams.color,
-        size: _.get(layerParams, 'markerSize', 'm'),
-        mapExtentFilter: {
-          geo_bounding_box: getGeoBoundingBox(),
-          geoField: getGeoField()
-        },
-        mainVisGeoFieldName: getGeoField().fieldname,
-        geoFieldName: layerParams.geoField,
-        searchSource: $scope.searchSource,
-        leafletMap: map.leafletMap,
-        zoom: map.leafletMap.getZoom()
+        ..._getDefaultVectorLayerOptions(layerParams, displayName, layerParams.id),
+        ...{
+          dsl: $scope.vis.aggs.toDsl(),
+          geoFieldName: layerParams.geoField,
+          setCurrentTimeFilter,
+          zoom: map.leafletMap.getZoom(),
+          isDragAndDrop: layerParams.isDragAndDrop
+        }
       };
 
       poi.getLayer(options, function (layer) {
@@ -380,38 +415,29 @@ define(function (require) {
       });
     }
 
-    function initVectorLayer(id, displayName, geoJsonCollection, options) {
+    function initVectorLayer(id, displayName, geoJsonCollection, layerParams) {
       spinControl.create();
       let popupFields = [];
-      if (_.get(options, 'popupFields') === '' || !_.get(options, 'popupFields')) {
+      if (_.get(layerParams, 'popupFields') === '' || !_.get(layerParams, 'popupFields')) {
         popupFields = [];
-      } else if (_.get(options, 'popupFields').indexOf(',') > -1) {
-        popupFields = _.get(options, 'popupFields').split(',');
+      } else if (_.get(layerParams, 'popupFields').indexOf(',') > -1) {
+        popupFields = _.get(layerParams, 'popupFields').split(',');
       } else {
-        popupFields = [_.get(options, 'popupFields', [])];
+        popupFields = [_.get(layerParams, 'popupFields', [])];
       }
 
-      const optionsWithDefaults = {
-        id,
-        displayName,
-        color: _.get(options, 'color', '#008800'),
-        size: _.get(options, 'size', 'm'),
-        popupFields,
-        layerGroup: _.get(options, 'layerGroup', '<b> Vector Overlays </b>'),
-        indexPattern: getIndexPatternId(),
-        geoFieldName: $scope.vis.aggs[1].params.field.name,
-        _siren: getSirenMeta(),
-        mapExtentFilter: {
-          geo_bounding_box: getGeoBoundingBox(),
-        },
-        type: _.get(options, 'type', 'noType'),
-        leafletMap: map.leafletMap
+      const options = {
+        ..._getDefaultVectorLayerOptions(layerParams, displayName, id),
+        ...{
+          indexPattern: getIndexPatternId(),
+          type: _.get(layerParams, 'type', 'noType'),
+          popupFields
+        }
       };
 
-      const layer = new Vector(geoJsonCollection).getLayer(optionsWithDefaults);
+      const layer = new Vector(geoJsonCollection).getLayer(options);
       layer.id = id;
-      map.addFeatureLayer(layer, optionsWithDefaults);
-
+      map.addFeatureLayer(layer, options);
     }
 
     /*
@@ -455,16 +481,13 @@ define(function (require) {
     });
 
     $scope.$watch('esResponse', function (resp) {
-      //handling a case where query is fired due to query or geofilter change
-      if (!$scope.flags.drawingAggs) {
-        if (_.has(resp, 'aggregations')) {
-          chartData = respProcessor.process(resp);
-          chartData.searchSource = $scope.searchSource;
-          if (_shouldAutoFitMapBoundsToData()) {
-            _doFitMapBoundsToData();
-          }
-          putAggregationLayerOnMap();
+      if (_.has(resp, 'aggregations')) {
+        chartData = respProcessor.process(resp);
+        chartData.searchSource = $scope.searchSource;
+        if (_shouldAutoFitMapBoundsToData()) {
+          _doFitMapBoundsToData();
         }
+        putAggregationLayerOnMap();
       }
     });
 
@@ -475,24 +498,31 @@ define(function (require) {
       }
     });
 
-    $scope.$listen(queryFilter, 'update', async function () {
+    //updating from query, time and auto-update
+    $scope.$listen(timefilter, 'update', () => drawLayersFromQueryOrTimeFilterUpdate());
+    $scope.$listen(queryFilter, 'update', () => drawLayersFromQueryOrTimeFilterUpdate());
+    $rootScope.$on('courier:searchRefresh', () => drawLayersFromQueryOrTimeFilterUpdate());
+
+    async function drawLayersFromQueryOrTimeFilterUpdate() {
       await setTooltipFormatter($scope.vis.params.tooltip, $scope.vis._siren);
-      //redraw these layers because they are specific to filters
+      _updateCurrentTimeFilter();
+      setCurrentTimeFilter($scope.searchSource);
+      //redraw these layers because they are specific to filters and time changes
       await drawAggregationLayer();
       _drawPoiLayers($scope.vis.params.overlays.savedSearches, true);
       _drawPoiLayers($scope.vis.params.overlays.dragAndDropPoiLayers, true);
       _drawGeoFilters();
-    });
+    }
 
     $scope.$on('$destroy', function () {
       binder.destroy();
       resizeChecker.destroy();
-      destroyKibiStateEvents();
+      _destroyKibiStateEvents();
       if (map) map.destroy();
       if (tooltip) tooltip.destroy();
     });
 
-    function destroyKibiStateEvents() {
+    function _destroyKibiStateEvents() {
       kibiState.off('drop_on_graph');
       kibiState.off('drag_on_graph');
     }
@@ -541,8 +571,7 @@ define(function (require) {
       _.each($scope.vis.params.overlays.wfsOverlays, wfsOverlay => {
         const options = {
           color: _.get(wfsOverlay, 'color', '#10aded'),
-          popupFields: _.get(wfsOverlay, 'popupFields', ''),
-          layerGroup: 'WFS Overlays'
+          popupFields: _.get(wfsOverlay, 'popupFields', '')
         };
 
         const url = wfsOverlay.url.substr(wfsOverlay.url.length - 5).toLowerCase() !== '/wfs?' ? wfsOverlay.url + '/wfs?' : wfsOverlay.url;
@@ -748,8 +777,6 @@ define(function (require) {
     }
 
     async function drawAggregationLayer(fromVisParams) {
-      $scope.flags.drawingAggs = true; // turns off the es watcher for the fetch in this function
-      let aggResp;
       let drawAggs;
       // checking that the agg has been configured,
       //e.g. a main spatial field has been set on new vis
@@ -757,12 +784,14 @@ define(function (require) {
         if (map._chartData && // if parameters haven't been assigned yet, fire the query
           (map.aggLayerParams && map.aggLayerParams.mapParams && map.aggLayerParams.mapParams.zoomLevel)) {
           const autoPrecision = _.get(map, '_chartData.geohashGridAgg.params.autoPrecision') || map.aggLayerParams.autoPrecision; //use previous as default
-          const layerOnMap = map._layerControl.getLayerById(map.aggLayerParams.id);
+          const layerOnMap = map._layerControl.getLayerById('Aggregation');
           if (!layerOnMap ||
             autoPrecision && utils.drawLayerCheck(map.aggLayerParams,
               _currentMapEnvironment.currentMapBounds,
               _currentMapEnvironment.currentZoom,
-              _currentMapEnvironment.currentAggregationPrecision)) {
+              _currentMapEnvironment.currentAggregationPrecision,
+              false,
+              _currentTimeFilter)) {
             drawAggs = true;
           } else if (!autoPrecision && (!utils.contains(map.aggLayerParams.mapParams.mapBounds, _currentMapEnvironment.currentMapBounds))) {
             drawAggs = true;
@@ -795,22 +824,21 @@ define(function (require) {
             zoomLevel: _currentMapEnvironment.currentZoom,
             precision: _currentMapEnvironment.currentAggregationPrecision
           };
-          aggResp = await $scope.searchSource.fetch();
+
+          map.aggLayerParams.currentTimeFilter = _currentTimeFilter;
+
+          await $scope.searchSource.fetch();
         }
 
-        if (_.has(aggResp, 'aggregations')) {
-          chartData = respProcessor.process(aggResp);
-          putAggregationLayerOnMap();
-        } else if (aggResp && aggResp.CourierFetchRequestStatus === 'aborted' && fromVisParams) {
-          // coming from vis.params when no changes are made,
-          // the search source fetch will be aborted
-          // so we redraw the aggs stored in memory as they are the same
-          putAggregationLayerOnMap();
-        } else if (isHeatMap()) {
-          map.fixMapTypeTooltips();
-        }
-
-        $scope.flags.drawingAggs = false;
+        // if (aggResp && aggResp.CourierFetchRequestStatus === 'aborted' && fromVisParams) {
+        //   // coming from vis.params when no changes are made,
+        //   // the search source fetch will be aborted
+        //   // so we redraw the aggs stored in memory as they are the same
+        //   // otherwise redrawing layer is handled by esResponse watcher
+        //   putAggregationLayerOnMap();
+        // } else if (isHeatMap()) {
+        //   map.fixMapTypeTooltips();
+        // }
       }
     }
     // ============================
@@ -888,7 +916,7 @@ define(function (require) {
       }
 
       if (e.layerType === 'poi_shape' || e.layerType === 'poi_point') {
-        const layerParams = getPoiLayerParamsById(e.id);
+        const layerParams = getPoiLayerParamsById(e.id, e.isDragAndDrop);
         layerParams.enabled = e.enabled;
         layerParams.type = e.layerType;
         const layerOnMap = map._layerControl.getLayerById(layerParams.id);
@@ -898,7 +926,8 @@ define(function (require) {
             _currentMapEnvironment.currentMapBounds,
             _currentMapEnvironment.currentZoom,
             _currentMapEnvironment.currentClusteringPrecision,
-            warning)) {
+            warning,
+            _currentTimeFilter)) {
           initPOILayer(layerParams);
         }
       } else if (e.layerType === 'agg') {
@@ -921,7 +950,7 @@ define(function (require) {
       }
 
       if (e.layerType === 'poi_shape' || e.layerType === 'poi_point') {
-        const layerParams = getPoiLayerParamsById(e.id);
+        const layerParams = getPoiLayerParamsById(e.id, e.isDragAndDrop);
         layerParams.enabled = false;
       } else if (map._markers && e.layerType === 'agg') {
         if (isHeatMap()) {

--- a/public/visController.js
+++ b/public/visController.js
@@ -833,16 +833,6 @@ define(function (require) {
 
           await $scope.searchSource.fetch();
         }
-
-        // if (aggResp && aggResp.CourierFetchRequestStatus === 'aborted' && fromVisParams) {
-        //   // coming from vis.params when no changes are made,
-        //   // the search source fetch will be aborted
-        //   // so we redraw the aggs stored in memory as they are the same
-        //   // otherwise redrawing layer is handled by esResponse watcher
-        //   putAggregationLayerOnMap();
-        // } else if (isHeatMap()) {
-        //   map.fixMapTypeTooltips();
-        // }
       }
     }
     // ============================

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -256,10 +256,8 @@ define(function (require) {
      * users context for all applied filters
      */
     TileMapMap.prototype.addFilters = function (filters) {
-      if (this._filters) {
-        if (this.leafletMap.hasLayer(this._filters)) {
-          this._filters.enabled = true;
-        }
+      if (this._filters && this.leafletMap.hasLayer(this._filters)) {
+        this._filters.enabled = true;
       }
 
       const style = {

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -473,6 +473,7 @@ define(function (require) {
 
       mapOptions.center = this._mapCenter;
       mapOptions.zoom = this._mapZoom;
+      mapOptions.worldCopyJump = true;
 
       this.leafletMap = L.map(this._container, mapOptions);
 

--- a/public/vislib/vector_layer_types/EsLayer.js
+++ b/public/vislib/vector_layer_types/EsLayer.js
@@ -163,10 +163,6 @@ export default class EsLayer {
       } else {
         layer.visible = true;
       }
-
-      layer.layerGroup = options.layerGroup;
-
-      return layer;
     } else {
       //when there is no data present for the current map canvas
       layer = L.geoJson();
@@ -187,8 +183,9 @@ export default class EsLayer {
       layer.options = { pane: 'overlayPane' };
 
       layer.visible = options.visible || true;
-      return layer;
     }
+    layer.isDragAndDrop = options.isDragAndDrop;
+    return layer;
   }
 
   isLine = function (type) {

--- a/public/vislib/vector_layer_types/POIs.js
+++ b/public/vislib/vector_layer_types/POIs.js
@@ -119,7 +119,7 @@ define(function (require) {
             // inherits from the savedSearch search source instead of main
             searchSource.inherits(savedSearch.searchSource);
             //_siren from main searchSource is used
-            searchSource._siren = options.searchSource._siren;
+            searchSource._siren = options._siren;
 
             if (onDashboardPage()) {
               allFilters = allFilters.concat(...searchSource.filter());
@@ -159,6 +159,7 @@ define(function (require) {
 
       const fetchData = async (searchSource) => {
         try {
+          options.setCurrentTimeFilter(searchSource);
           return await searchSource.fetch();
         } catch (e) {
           notify.warning(`Unsuccessful POI fetch request - ${e}`);

--- a/public/vislib/vector_layer_types/vector.js
+++ b/public/vislib/vector_layer_types/vector.js
@@ -93,7 +93,7 @@ export default class Vector {
                 polygon._map.fire('etm:select-feature-vector', {
                   args: {
                     _siren: options._siren,
-                    geoFieldName: options.geoFieldName,
+                    geoFieldName: options.mainVisGeoFieldName,
                     indexPattern: options.indexPattern,
                     type: feature.geometry.type
                   },


### PR DESCRIPTION
Fix for - https://sirensolutions.atlassian.net/browse/INVE-11718
To be merged with - https://github.com/sirensolutions/kibi-internal/pull/12477

Main fix:
- When map is panned/zoomed, relative time filter dashboards do not update, they stay the same as other visualizations on the dashboard
- Auto refresh dashboard is now also updates map layers (not stored layers as it is not their intention for now, was just for queryfilter bar previously)
- Map layers will update when time filter is changed (was just for queryfilter bar previously)
- Aggregation layer renders just once when panning/zooming map. Previously it rendered from `esResponse` watcher as well as manually from the `drawAggregationLayer` function. Now, the fetch is called from funciton and all rendering is handled in `esResponse`

Some other things fixed: 
- Drag and drop layers weren't working because wrong array was searched
- Tidied up options for vector and poi overlays in vis controller. Now there is less duplication, meaning to do that for a while :) 

Still to do: 

- [x] Unit tests for additions to drawLayerCheck in `utils.js`
- [x] Manual test (more from me as there are some big changes here)
