### PR TITLE
Using tilemap server configured in investigate.yml

### DIFF
--- a/public/visController.js
+++ b/public/visController.js
@@ -29,7 +29,7 @@ define(function (require) {
     kibiState, savedSearches, savedDashboards, dashboardGroups, savedVisualizations,
     $scope, $rootScope, $element, $timeout, joinExplanation,
     Private, courier, config, getAppState, indexPatterns, $http, $injector,
-    timefilter, createNotifier, es, sirenSession, $route) {
+    timefilter, createNotifier, es, sirenSession, $route, serviceSettings) {
     const buildChartData = Private(VislibVisTypeBuildChartDataProvider);
     const queryFilter = Private(FilterBarQueryFilterProvider);
     const callbacks = Private(require('plugins/enhanced_tilemap/callbacks'));
@@ -75,6 +75,7 @@ define(function (require) {
       sirenSessionState.register(uiState, sirenSession, $route.current.params.id, $scope.vis.id);
       createDragAndDropPoiLayers();
       appendMap();
+      map.createBaseLayer(getTileMapFromInvestigateYaml, map._attr.wms.url, map._attr.wms.options, _.get(map, '_attr.wms.enabled', null));
       modifyToDsl();
       await setTooltipFormatter($scope.vis.params.tooltip, $scope.vis._siren);
       drawWfsOverlays();
@@ -442,7 +443,7 @@ define(function (require) {
 
         map.removeAllLayersFromMapandControl();
         // base layer
-        map.redrawDefaultMapLayers(visParams.wms.url, visParams.wms.options, visParams.wms.enabled);
+        map.createBaseLayer(null, visParams.wms.url, visParams.wms.options, visParams.wms.enabled);
         await setTooltipFormatter(visParams.tooltip, $scope.vis._siren);
 
         if (isHeatMap()) {
@@ -694,6 +695,10 @@ define(function (require) {
       }
     }
 
+    async function getTileMapFromInvestigateYaml() {
+      const tmsService = await serviceSettings.getTMSService();
+      return tmsService.getTMSOptions();
+    }
 
     function appendMap() {
       const params = $scope.vis.params;

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -449,7 +449,7 @@ define(function (require) {
       return isSame;
     };
 
-    TileMapMap.prototype.createBaseLayer = async function (getTileMapFromInvestigateYaml = false, url, options, enabled) {
+    TileMapMap.prototype.createBaseLayer = async function (getTileMapFromInvestigateYaml = null, url, options, enabled) {
       if (this._tileLayer) this._tileLayer.remove();
       if (getTileMapFromInvestigateYaml) {
         mapTiles = await getDefaultBaseLayer(getTileMapFromInvestigateYaml);

--- a/public/vislib/_map.js
+++ b/public/vislib/_map.js
@@ -23,18 +23,26 @@ define(function (require) {
     const defaultMapCenter = [15, 5];
     const defaultMarkerType = 'Scaled Circle Markers';
 
-    const mapTiles = {
-      url: '//a.tile.openstreetmap.org/{z}/{x}/{y}.png',
-      options: {
-        attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors'
-      }
-    };
+    let mapTiles;
+
     const markerTypes = {
       'Scaled Circle Markers': Private(require('./marker_types/scaled_circles')),
       'Shaded Circle Markers': Private(require('./marker_types/shaded_circles')),
       'Shaded Geohash Grid': Private(require('./marker_types/geohash_grid')),
       'Heatmap': Private(require('./marker_types/heatmap')),
     };
+
+    async function getDefaultBaseLayer(getTileMapFromInvestigateYaml) {
+      const tmsFromYaml = await getTileMapFromInvestigateYaml();
+      return {
+        url: tmsFromYaml.url || '//a.tile.openstreetmap.org/{z}/{x}/{y}.png',
+        options: {
+          maxZoom: tmsFromYaml.maxZoom || 18,
+          minZoom: tmsFromYaml.minZoom || 0,
+          attribution: tmsFromYaml.attribution || 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors'
+        }
+      };
+    }
 
     /**
      * Tile Map Maps
@@ -441,45 +449,33 @@ define(function (require) {
       return isSame;
     };
 
-    TileMapMap.prototype.redrawDefaultMapLayers = function (url, options, enabled) {
+    TileMapMap.prototype.createBaseLayer = async function (getTileMapFromInvestigateYaml = false, url, options, enabled) {
+      if (this._tileLayer) this._tileLayer.remove();
+      if (getTileMapFromInvestigateYaml) {
+        mapTiles = await getDefaultBaseLayer(getTileMapFromInvestigateYaml);
+      }
+
       // Use WMS compliant server, if not enabled, use OSM mapTiles as default
       if (enabled) {
-        this._tileLayer.remove();
         this._tileLayer = L.tileLayer.wms(url, options);
       } else {
-        this._tileLayer.remove();
         this._tileLayer = L.tileLayer(mapTiles.url, mapTiles.options);
       }
-      this._tileLayer.setZIndex(-10);
       this._tileLayer.type = 'base';
+      this._tileLayer.setZIndex(-10);
+      // add base layer based on above logic and decide saturation based on saved settings
       this._tileLayer.addTo(this.leafletMap);
-      this.saturateTile(this._attr.isDesaturated, this._tileLayer);
 
-      // see note in _addDrawControl function
-      // this._layerControl.addOverlays([this._drawnItems]);
+      this.saturateTile(this._attr.isDesaturated, this._tileLayer);
     };
 
     TileMapMap.prototype._createMap = function (mapOptions) {
       if (this.leafletMap) this.destroy();
 
-      // Use WMS compliant server, if not enabled, use OSM mapTiles as default
-      if (this._attr.wms && this._attr.wms.enabled) {
-        this._tileLayer = L.tileLayer.wms(this._attr.wms.url, this._attr.wms.options);
-      } else {
-        this._tileLayer = L.tileLayer(mapTiles.url, mapTiles.options);
-      }
-      this._tileLayer.type = 'base';
-      this._tileLayer.setZIndex(-10);
-
       mapOptions.center = this._mapCenter;
       mapOptions.zoom = this._mapZoom;
 
       this.leafletMap = L.map(this._container, mapOptions);
-
-      // add base layer based on above logic and decide saturation based on saved settings
-      this._tileLayer.addTo(this.leafletMap);
-
-      this.saturateTile(this._attr.isDesaturated, this._tileLayer);
 
       this._layerControl = L.control.dndLayerControl(this.allLayers, this.esClient, this.mainSearchDetails, this.$element);
       this._layerControl.addTo(this.leafletMap);


### PR DESCRIPTION
I copied one of these into investigate.yml, restarted investigate and loaded an enhanced coordinate map visualization with WMS server turned off in Map options in edit mode. Then repeated the process for the second one (Investigate crashes with a duplicated key error if two are added). Seems fine: 

Mapbox url:
```
tilemap:
  url: "https://api.mapbox.com/styles/v1/mapbox/streets-v9/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoiZW5nY29kYSIsImEiOiJjanVxcGEzemcyOTZ3M3pueDg5b3Vzc25hIn0.59azAbNI5tb-JWyLp5RgKw"
  options:
    attribution: '[© Mapbox](https://www.mapbox.com/about/maps/)[© OpenStreetMap](http://www.openstreetmap.org/about/)'
    minZoom: 0
    maxZoom: 19
   ``` 
XYZ tile server from https://leaflet-extras.github.io/leaflet-providers/preview/ :
```
 tilemap:
  url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'
  options:
    attribution: '&copy; [OpenStreetMap]("http://www.openstreetmap.org/copyright")'
    subdomains:
      - a
 ```